### PR TITLE
8280526: x86_32 Math.sqrt performance regression with -XX:UseSSE={0,1}

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1607,9 +1607,14 @@ const bool Matcher::match_rule_supported(int opcode) {
       }
       break;
     case Op_SqrtD:
+#ifdef _LP64
       if (UseSSE < 2) {
         return false;
       }
+#else
+      // x86_32.ad has a special match rule for SqrtD.
+      // Together with common x86 rules, this handles all UseSSE cases.
+#endif
       break;
   }
   return true;  // Match rules are supported by default.


### PR DESCRIPTION
Clean backport to fix the recent regression.

Additional testing:
 - [x] `compiler/loopopts/superword/SumRedSqrt_Double.java` does not timeout anymore

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280526](https://bugs.openjdk.java.net/browse/JDK-8280526): x86_32 Math.sqrt performance regression with -XX:UseSSE={0,1}


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/9.diff">https://git.openjdk.java.net/jdk18u/pull/9.diff</a>

</details>
