### PR TITLE
8280910: Update openjdk project in jcheck to "jdk-updates" for jdk18u

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,5 +1,5 @@
 [general]
-project=jdk
+project=jdk-updates
 jbs=JDK
 version=18.0.1
 


### PR DESCRIPTION
The openjdk project in jcheck should be changed to "jdk-updates" for jdk18u

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280910](https://bugs.openjdk.java.net/browse/JDK-8280910): Update openjdk project in jcheck to "jdk-updates" for jdk18u


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/11.diff">https://git.openjdk.java.net/jdk18u/pull/11.diff</a>

</details>
