### PR TITLE
8280950: RandomGenerator:NextDouble() default behavior non conformant after JDK-8280550 fix

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -645,7 +645,7 @@ public class RandomSupport {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound)  // may need to correct a rounding problem
-                r = Math.nextAfter(r, origin);
+                r = Math.nextAfter(bound, origin);
         }
         return r;
     }

--- a/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
+++ b/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
@@ -24,13 +24,19 @@
 /*
  * @test
  * @summary Verify nextDouble stays within range
- * @bug 8280550
+ * @bug 8280550 8280950
  */
 
 import java.util.SplittableRandom;
+import java.util.random.RandomGenerator;
 
 public class RandomNextDoubleBoundary {
     public static void main(String... args) {
+        negativeBounds();
+        positiveBounds();
+    }
+
+    private static void negativeBounds() {
         // Both bounds are negative
         double lowerBound = -1.0000000000000002;
         double upperBound = -1.0;
@@ -47,6 +53,39 @@ public class RandomNextDoubleBoundary {
             System.err.println("r = " + r + "\t" + Double.toHexString(r));
             System.err.println("lb = " + lowerBound + "\t" + Double.toHexString(lowerBound));
             throw new RuntimeException("Less than lower bound");
+        }
+    }
+
+    private static void positiveBounds() {
+        double[][] originAndBounds = {{10, 100},
+                                      {12345, 123456},
+                                      {5432167.234, 54321678.1238}};
+        for (double[] originAndBound : originAndBounds) {
+            nextDoublesWithRange(originAndBound[0], originAndBound[1]);
+        }
+    }
+
+    public static void nextDoublesWithRange(double origin, double bound) {
+        RandomGenerator rg = new RandomGenerator() {
+            @Override
+            public double nextDouble() {
+                return Double.MAX_VALUE;
+            }
+
+            @Override
+            public long nextLong() {
+                return 0;
+            }
+        };
+        double value = rg.nextDouble(origin, bound);
+
+        assertTrue(value >= origin);
+        assertTrue(value < bound);
+    }
+
+    public static void assertTrue(boolean condition) {
+        if (!condition) {
+            throw new AssertionError();
         }
     }
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280950](https://bugs.openjdk.java.net/browse/JDK-8280950): RandomGenerator:NextDouble() default behavior non conformant after JDK-8280550 fix


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/22.diff">https://git.openjdk.java.net/jdk18u/pull/22.diff</a>

</details>
