### PR TITLE
8281183: RandomGenerator:NextDouble() default behavior partially fixed by JDK-8280950

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -677,7 +677,7 @@ public class RandomSupport {
         double r = rng.nextDouble();
         r = r * bound;
         if (r >= bound)  // may need to correct a rounding problem
-            r = Math.nextDown(r);
+            r = Math.nextDown(bound);
         return r;
     }
 

--- a/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
+++ b/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Verify nextDouble stays within range
- * @bug 8280550 8280950
+ * @bug 8280550 8280950 8281183
  */
 
 import java.util.SplittableRandom;
@@ -79,8 +79,11 @@ public class RandomNextDoubleBoundary {
         };
         double value = rg.nextDouble(origin, bound);
 
-        assertTrue(value >= origin);
-        assertTrue(value < bound);
+        if (bound > 0) {
+            value = rg.nextDouble(bound); // Equivalent to nextDouble(0.0, bound)
+            assertTrue(value >= 0.0);
+            assertTrue(value < bound);
+        }
     }
 
     public static void assertTrue(boolean condition) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281183](https://bugs.openjdk.java.net/browse/JDK-8281183): RandomGenerator:NextDouble() default behavior partially fixed by JDK-8280950


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/23.diff">https://git.openjdk.java.net/jdk18u/pull/23.diff</a>

</details>
