### PR TITLE
8276819: javax/print/PrintServiceLookup/FlushCustomClassLoader.java fails to free

### DIFF
--- a/test/jdk/javax/print/PrintServiceLookup/FlushCustomClassLoader.java
+++ b/test/jdk/javax/print/PrintServiceLookup/FlushCustomClassLoader.java
@@ -34,6 +34,9 @@ import javax.print.PrintServiceLookup;
  * @test
  * @bug 8273831
  * @summary Tests custom class loader cleanup
+ * @library /javax/swing/regtesthelpers
+ * @build Util
+ * @run main/timeout=60/othervm -mx32m FlushCustomClassLoader
  */
 public final class FlushCustomClassLoader {
 
@@ -42,12 +45,8 @@ public final class FlushCustomClassLoader {
 
         int attempt = 0;
         while (loader.get() != null) {
-            if (++attempt > 10) {
-                throw new RuntimeException("Too many attempts: " + attempt);
-            }
-            System.gc();
-            Thread.sleep(1000);
-            System.out.println("Not freed, attempt: " + attempt);
+            Util.generateOOME();
+            System.out.println("Not freed, attempt: " + attempt++);
         }
     }
 


### PR DESCRIPTION
Hi all,
This is a test stabilization fix, additional information [here](https://github.com/openjdk/jdk/pull/6778).
This pull request contains a backport of commit [7c2c5858](https://github.com/openjdk/jdk/commit/7c2c58587d4eda5523331eae45e7d897252dc097) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 12 Dec 2021 and was reviewed by Prasanta Sadhukhan and Alexey Ivanov.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276819](https://bugs.openjdk.java.net/browse/JDK-8276819): javax/print/PrintServiceLookup/FlushCustomClassLoader.java fails to free


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/24.diff">https://git.openjdk.java.net/jdk18u/pull/24.diff</a>

</details>
