### PR TITLE
8281262: Windows builds in different directories are not fully reproducible

### DIFF
--- a/make/TestImage.gmk
+++ b/make/TestImage.gmk
@@ -35,8 +35,8 @@ BUILD_INFO_PROPERTIES := $(TEST_IMAGE_DIR)/build-info.properties
 $(BUILD_INFO_PROPERTIES):
 	$(call MakeTargetDir)
 	$(ECHO) "# Build info properties for JDK tests" > $@
-	$(ECHO) "build.workspace.root=$(call FixPath, $(WORKSPACE_ROOT))" >> $@
-	$(ECHO) "build.output.root=$(call FixPath, $(OUTPUTDIR))" >> $@
+	$(ECHO) 'build.workspace.root=$(call FixPath, $(WORKSPACE_ROOT))' >> $@
+	$(ECHO) 'build.output.root=$(call FixPath, $(OUTPUTDIR))' >> $@
 
 README := $(TEST_IMAGE_DIR)/Readme.txt
 

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -782,10 +782,8 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
         test "x$ENABLE_REPRODUCIBLE_BUILD" = xtrue; then
       # There is a known issue with the pathmap if the mapping is made to the
       # empty string. Add a minimal string "s" as prefix to work around this.
-      workspace_root_win=`$FIXPATH_BASE print "${WORKSPACE_ROOT%/}"`
       # PATHMAP_FLAGS is also added to LDFLAGS in flags-ldflags.m4.
-      PATHMAP_FLAGS="-pathmap:${workspace_root_win//\//\\\\}=s \
-          -pathmap:${workspace_root_win}=s"
+      PATHMAP_FLAGS="-pathmap:${WORKSPACE_ROOT}=s"
       FILE_MACRO_CFLAGS="$PATHMAP_FLAGS"
       FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [${FILE_MACRO_CFLAGS}],
           PREFIX: $3,

--- a/test/jdk/build/AbsPathsInImage.java
+++ b/test/jdk/build/AbsPathsInImage.java
@@ -96,6 +96,13 @@ public class AbsPathsInImage {
         if (buildOutputRoot == null) {
             throw new Error("Could not find build output root, test cannot run");
         }
+        // Validate the root paths
+        if (!Paths.get(buildWorkspaceRoot).isAbsolute()) {
+            throw new Error("Workspace root is not an absolute path: " + buildWorkspaceRoot);
+        }
+        if (!Paths.get(buildOutputRoot).isAbsolute()) {
+            throw new Error("Output root is not an absolute path: " + buildOutputRoot);
+        }
 
         List<byte[]> searchPatterns = new ArrayList<>();
         expandPatterns(searchPatterns, buildWorkspaceRoot);


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281262](https://bugs.openjdk.java.net/browse/JDK-8281262): Windows builds in different directories are not fully reproducible


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/26.diff">https://git.openjdk.java.net/jdk18u/pull/26.diff</a>

</details>
