### PR TITLE
8281275: Upgrading from 8 to 11 no longer accepts '/' as filepath separator in gc paths

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -365,9 +365,9 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
     // Find the next colon or quote
     char* next = strpbrk(str, ":\"");
 #ifdef _WINDOWS
-    // Skip over Windows paths such as "C:\..."
-    // Handle both C:\... and file=C:\..."
-    if (next != NULL && next[0] == ':' && next[1] == '\\') {
+    // Skip over Windows paths such as "C:\..." and "C:/...".
+    // Handles both "C:\..." and "file=C:\...".
+    if (next != NULL && next[0] == ':' && (next[1] == '\\' || next[1] == '/')) {
       if (next == str + 1 || (strncmp(str, "file=", 5) == 0)) {
         next = strpbrk(next + 1, ":\"");
       }


### PR DESCRIPTION
Backport of JDK-8281275 to JDK-18u.  Patch applied cleanly and backport was tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows.
Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281275](https://bugs.openjdk.java.net/browse/JDK-8281275): Upgrading from 8 to 11 no longer accepts '/' as filepath separator in gc paths


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/27.diff">https://git.openjdk.java.net/jdk18u/pull/27.diff</a>

</details>
