### PR TITLE
8281093: Violating Attribute-Value Normalization in the XML specification 1.0

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityScanner.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 
 /*
@@ -57,7 +57,7 @@ import java.util.Locale;
  * @author Arnaud  Le Hors, IBM
  * @author K.Venugopal Sun Microsystems
  *
- * @LastModified: Sep 2021
+ * @LastModified: Mar 2022
  */
 public class XMLEntityScanner implements XMLLocator  {
 
@@ -2162,7 +2162,7 @@ public class XMLEntityScanner implements XMLLocator  {
                             break;
                         }
                     }
-                    if (c == '\r') {
+                    if (c == '\r' && isExternal) {
                         int cc = fCurrentEntity.ch[fCurrentEntity.position];
                         if (cc == '\n' || (version == XML_VERSION_1_1 && cc == 0x85)) {
                             fCurrentEntity.position++;


### PR DESCRIPTION
Clean backport of https://github.com/openjdk/jdk/commit/3996782c5af7b0396d5133fab457c507758d9340 to jdk18u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281093](https://bugs.openjdk.java.net/browse/JDK-8281093): Violating Attribute-Value Normalization in the XML specification 1.0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/35.diff">https://git.openjdk.java.net/jdk18u/pull/35.diff</a>

</details>
