### PR TITLE
8281318: Improve jfr/event/allocation tests reliability

### DIFF
--- a/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java
+++ b/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java
@@ -30,6 +30,8 @@ import jdk.jfr.consumer.RecordedEvent;
 import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Platform;
+import sun.hotspot.WhiteBox;
 
 /**
  * @test
@@ -37,8 +39,16 @@ import jdk.test.lib.Asserts;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
- * @run main/othervm -XX:+UseTLAB -XX:TLABSize=100k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=1 jdk.jfr.event.allocation.TestObjectAllocationInNewTLABEvent
- * @run main/othervm -XX:+UseTLAB -XX:TLABSize=100k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=1 -Xint jdk.jfr.event.allocation.TestObjectAllocationInNewTLABEvent
+ * @build sun.hotspot.WhiteBox
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -XX:+UseTLAB -XX:TLABSize=100k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=1
+ *                   jdk.jfr.event.allocation.TestObjectAllocationInNewTLABEvent
+ * @run main/othervm -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -XX:+UseTLAB -XX:TLABSize=100k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=1
+ *                   -Xint
+ *                   jdk.jfr.event.allocation.TestObjectAllocationInNewTLABEvent
  */
 
 /**
@@ -46,17 +56,19 @@ import jdk.test.lib.Asserts;
  * an event will be triggered. The test is done for default and interpreted mode (-Xint).
  *
  * To force objects to be allocated in a new TLAB:
- *      the size of TLAB is set to 100k (-XX:TLABSize=100k);
- *      the size of allocated objects is set to 100k minus 16 bytes overhead;
+ *      the initial size of TLAB is set to 100k (-XX:TLABSize=100k);
+ *      the size of allocated objects is set to 128k;
  *      max TLAB waste at refill is set to minimum (-XX:TLABRefillWasteFraction=1),
  *          to provoke a new TLAB creation.
  */
 public class TestObjectAllocationInNewTLABEvent {
     private final static String EVENT_NAME = EventNames.ObjectAllocationInNewTLAB;
 
-    private static final int BYTE_ARRAY_OVERHEAD = 16; // Extra bytes used by a byte array.
-    private static final int OBJECT_SIZE  = 100 * 1024;
-    private static final int OBJECT_SIZE_ALT = OBJECT_SIZE + 8; // Object size in case of disabled CompressedOops.
+    private static final Boolean COMPRESSED_CLASS_PTRS = WhiteBox.getWhiteBox().getBooleanVMFlag("UseCompressedClassPointers");
+
+    private static final int BYTE_ARRAY_OVERHEAD = (Platform.is64bit() && !COMPRESSED_CLASS_PTRS) ? 24 : 16;
+    private static final int OBJECT_SIZE = 128 * 1024;
+
     private static final int OBJECTS_TO_ALLOCATE = 100;
     private static final String BYTE_ARRAY_CLASS_NAME = new byte[0].getClass().getName();
     private static final int INITIAL_TLAB_SIZE = 100 * 1024;
@@ -112,9 +124,9 @@ public class TestObjectAllocationInNewTLABEvent {
         long allocationSize = Events.assertField(event, "allocationSize").atLeast(1L).getValue();
         long tlabSize = Events.assertField(event, "tlabSize").atLeast(allocationSize).getValue();
         String className = Events.assertField(event, "objectClass.name").notEmpty().getValue();
-        if (className.equals(BYTE_ARRAY_CLASS_NAME) && (allocationSize == OBJECT_SIZE || allocationSize == OBJECT_SIZE_ALT)) {
+        if (className.equals(BYTE_ARRAY_CLASS_NAME) && (allocationSize == OBJECT_SIZE)) {
             countAllTlabs++;
-            if (tlabSize == INITIAL_TLAB_SIZE + OBJECT_SIZE || tlabSize == INITIAL_TLAB_SIZE + OBJECT_SIZE_ALT) {
+            if (tlabSize == INITIAL_TLAB_SIZE + OBJECT_SIZE) {
                 countFullTlabs++;
             }
         }

--- a/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationOutsideTLABEvent.java
+++ b/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationOutsideTLABEvent.java
@@ -30,6 +30,8 @@ import jdk.jfr.consumer.RecordedEvent;
 import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Platform;
+import sun.hotspot.WhiteBox;
 
 /**
  * @test
@@ -37,8 +39,16 @@ import jdk.test.lib.Asserts;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
- * @run main/othervm -XX:+UseTLAB -XX:TLABSize=90k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=256 jdk.jfr.event.allocation.TestObjectAllocationOutsideTLABEvent
- * @run main/othervm -XX:+UseTLAB -XX:TLABSize=90k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=256 -Xint jdk.jfr.event.allocation.TestObjectAllocationOutsideTLABEvent
+ * @build sun.hotspot.WhiteBox
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -XX:+UseTLAB -XX:TLABSize=90k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=256
+ *                   jdk.jfr.event.allocation.TestObjectAllocationOutsideTLABEvent
+ * @run main/othervm -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -XX:+UseTLAB -XX:TLABSize=90k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=256
+ *                   -Xint
+ *                   jdk.jfr.event.allocation.TestObjectAllocationOutsideTLABEvent
  */
 
 /**
@@ -46,17 +56,19 @@ import jdk.test.lib.Asserts;
  * Thread Local Allocation Buffer (TLAB). The test is done for default interpreted mode (-Xint).
  *
  * To force objects to be allocated outside TLAB:
- *      the size of TLAB is set to 90k (-XX:TLABSize=90k);
- *      the size of allocated objects is set to 100k.
+ *      the initial size of TLAB is set to 90k (-XX:TLABSize=90k);
+ *      the size of allocated objects is set to 128k;
  *      max TLAB waste at refill is set to 256 (-XX:TLABRefillWasteFraction=256),
  *          to prevent a new TLAB creation.
 */
 public class TestObjectAllocationOutsideTLABEvent {
     private static final String EVENT_NAME = EventNames.ObjectAllocationOutsideTLAB;
 
-    private static final int BYTE_ARRAY_OVERHEAD = 16; // Extra bytes used by a byte array
-    private static final int OBJECT_SIZE = 100 * 1024;
-    private static final int OBJECT_SIZE_ALT = OBJECT_SIZE + 8; // Object size in case of disabled CompressedOops
+    private static final Boolean COMPRESSED_CLASS_PTRS = WhiteBox.getWhiteBox().getBooleanVMFlag("UseCompressedClassPointers");
+
+    private static final int BYTE_ARRAY_OVERHEAD = (Platform.is64bit() && !COMPRESSED_CLASS_PTRS) ? 24 : 16;
+    private static final int OBJECT_SIZE = 128 * 1024;
+
     private static final int OBJECTS_TO_ALLOCATE = 100;
     private static final String BYTE_ARRAY_CLASS_NAME = new byte[0].getClass().getName();
     private static int eventCount;
@@ -94,7 +106,7 @@ public class TestObjectAllocationOutsideTLABEvent {
         }
         long allocationSize = Events.assertField(event, "allocationSize").atLeast(1L).getValue();
         String className = Events.assertField(event, "objectClass.name").notEmpty().getValue();
-        if (className.equals(BYTE_ARRAY_CLASS_NAME) && (allocationSize == OBJECT_SIZE || allocationSize == OBJECT_SIZE_ALT)) {
+        if (className.equals(BYTE_ARRAY_CLASS_NAME) && (allocationSize == OBJECT_SIZE)) {
             ++eventCount;
         }
     }

--- a/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationSampleEventThrottling.java
+++ b/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationSampleEventThrottling.java
@@ -32,6 +32,8 @@ import jdk.jfr.consumer.RecordedEvent;
 import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Platform;
+import sun.hotspot.WhiteBox;
 
 /**
  * @test
@@ -39,15 +41,22 @@ import jdk.test.lib.Asserts;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
-*  @run main/othervm -XX:+UseTLAB -XX:TLABSize=2k -XX:-ResizeTLAB jdk.jfr.event.allocation.TestObjectAllocationSampleEventThrottling
+ * @build sun.hotspot.WhiteBox
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -XX:+UseTLAB -XX:TLABSize=2k -XX:-ResizeTLAB
+ *                   jdk.jfr.event.allocation.TestObjectAllocationSampleEventThrottling
  */
 
 public class TestObjectAllocationSampleEventThrottling {
     private static final String EVENT_NAME = EventNames.ObjectAllocationSample;
 
-    private static final int BYTE_ARRAY_OVERHEAD = 16; // Extra bytes used by a byte array
-    private static final int OBJECT_SIZE = 100 * 1024;
-    private static final int OBJECT_SIZE_ALT = OBJECT_SIZE + 8; // Object size in case of disabled CompressedOops
+    private static final Boolean COMPRESSED_CLASS_PTRS = WhiteBox.getWhiteBox().getBooleanVMFlag("UseCompressedClassPointers");
+
+    private static final int BYTE_ARRAY_OVERHEAD = (Platform.is64bit() && !COMPRESSED_CLASS_PTRS) ? 24 : 16;
+    private static final int OBJECT_SIZE = 128 * 1024;
+
     private static final int OBJECTS_TO_ALLOCATE = 100;
     private static final String BYTE_ARRAY_CLASS_NAME = new byte[0].getClass().getName();
     private static int eventCount;


### PR DESCRIPTION
Clean backport to improve JFR tests on x86_32.
Needs [JDK-8281638](https://bugs.openjdk.java.net/browse/JDK-8281638) as the follow-up.

Additional testing:
 - [x] Linux x86_32 fastdebug, affected tests fail without the patch, pass with it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281318](https://bugs.openjdk.java.net/browse/JDK-8281318): Improve jfr/event/allocation tests reliability


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/42.diff">https://git.openjdk.java.net/jdk18u/pull/42.diff</a>

</details>
