### PR TITLE
8282295: SymbolPropertyEntry::set_method_type fails with assert

### DIFF
--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -1236,6 +1236,7 @@ bool Universe::release_fullgc_alot_dummy() {
     if (_fullgc_alot_dummy_next >= fullgc_alot_dummy_array->length()) {
       // No more dummies to release, release entire array instead
       _fullgc_alot_dummy_array.release(Universe::vm_global());
+      _fullgc_alot_dummy_array = OopHandle(); // NULL out OopStorage pointer.
       return false;
     }
 


### PR DESCRIPTION
Backport of the fix for JDK-8282295.  Patch applied cleanly and was tested with Mach5 tiers 1-2.
Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282295](https://bugs.openjdk.java.net/browse/JDK-8282295): SymbolPropertyEntry::set_method_type fails with assert


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/49.diff">https://git.openjdk.java.net/jdk18u/pull/49.diff</a>

</details>
