### PR TITLE
8283350: (tz) Update Timezone Data to 2022a

### DIFF
--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2021e
+tzdata2022a

--- a/make/data/tzdata/africa
+++ b/make/data/tzdata/africa
@@ -941,6 +941,10 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 #         (car (cdr (cdr a))) (calendar-month-name (car a) t) (car (cdr a))
 #         (car (cdr (cdr b))) (calendar-month-name (car b) t) (car (cdr b)))))
 #     (setq islamic-year (+ 1 islamic-year))))
+#
+# From Milamber (2021-03-31, 2022-03-10), confirming these predictions:
+# https://www.mmsp.gov.ma/fr/actualites.aspx?id=2076
+# https://www.ecoactu.ma/horaires-administration-ramadan-gmtheure-gmt-a-partir-de-dimanche-27-mars/
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Morocco	1939	only	-	Sep	12	 0:00	1:00	-

--- a/make/data/tzdata/asia
+++ b/make/data/tzdata/asia
@@ -3429,8 +3429,12 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # ... winter time will begin in Palestine from Friday 10-29, 01:00 AM
 # by 60 minutes backwards.
 #
-# From Paul Eggert (2021-10-20):
-# Guess future fall transitions on October's last Friday at 01:00.
+# From Tim Parenti (2021-10-25), per Paul Eggert (2021-10-24):
+# Guess future fall transitions at 01:00 on the Friday preceding October's
+# last Sunday (i.e., Fri>=23), as this is more consistent with recent practice.
+
+# From Heba Hamad (2022-03-10):
+# summer time will begin in Palestine from Sunday 03-27-2022, 00:00 AM.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule EgyptAsia	1957	only	-	May	10	0:00	1:00	S
@@ -3466,9 +3470,10 @@ Rule Palestine	2016	2018	-	Mar	Sat>=24	1:00	1:00	S
 Rule Palestine	2016	2018	-	Oct	Sat>=24	1:00	0	-
 Rule Palestine	2019	only	-	Mar	29	0:00	1:00	S
 Rule Palestine	2019	only	-	Oct	Sat>=24	0:00	0	-
-Rule Palestine	2020	max	-	Mar	Sat>=24	0:00	1:00	S
+Rule Palestine	2020	2021	-	Mar	Sat>=24	0:00	1:00	S
 Rule Palestine	2020	only	-	Oct	24	1:00	0	-
-Rule Palestine	2021	max	-	Oct	lastFri	1:00	0	-
+Rule Palestine	2021	max	-	Oct	Fri>=23	1:00	0	-
+Rule Palestine	2022	max	-	Mar	Sun>=25	0:00	1:00	S
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Gaza	2:17:52	-	LMT	1900 Oct

--- a/make/data/tzdata/europe
+++ b/make/data/tzdata/europe
@@ -2808,8 +2808,26 @@ Zone Europe/Kaliningrad	 1:22:00 -	LMT	1893 Apr
 # says he remembers that Samara opted out of the 1992-01-19 exception
 # 2 days before the switch.
 #
+# From Alois Treindl (2022-02-15):
+# the Russian wikipedia page
+# https://ru.wikipedia.org/wiki/Московское_время#Перемещение_границы_применения_московского_времени_на_восток
+# contains the sentence (in Google translation) "In the autumn of
+# 1981, Arkhangelsk, Vologda, Yaroslavl, Ivanovo, Vladimir, Ryazan,
+# Lipetsk, Voronezh, Rostov-on-Don, Krasnodar and regions to the east
+# of those named (about 30 in total) parted ways with Moscow time.
+# However, the convenience of common time with Moscow turned out to be
+# decisive - in 1982, these regions again switched to Moscow time."
+# Shanks International atlas has similar information, and also the
+# Russian book Zaitsev A., Kutalev D. A new astrologer's reference
+# book. Coordinates of cities and time corrections, - The World of
+# Urania, 2012 (Russian: Зайцев А., Куталёв Д., Новый справочник
+# астролога. Координаты городов и временные поправки).
+# To me it seems that an extra zone is needed, which starts with LMT
+# util 1919, later follows Moscow since 1930, but deviates from it
+# between 1 October 1981 until 1 April 1982.
 #
-# From Paul Eggert (2016-03-18):
+#
+# From Paul Eggert (2022-02-15):
 # Given the above, we appear to be missing some Zone entries for the
 # chaotic early 1980s in Russia.  It's not clear what these entries
 # should be.  For now, sweep this under the rug and just document the
@@ -2856,7 +2874,7 @@ Zone Europe/Simferopol	 2:16:24 -	LMT	1880
 			 1:00	C-Eur	CE%sT	1944 Apr 13
 			 3:00	Russia	MSK/MSD	1990
 			 3:00	-	MSK	1990 Jul  1  2:00
-			 2:00	-	EET	1992
+			 2:00	-	EET	1992 Mar 20
 # Central Crimea used Moscow time 1994/1997.
 #
 # From Paul Eggert (2006-03-22):
@@ -2866,7 +2884,7 @@ Zone Europe/Simferopol	 2:16:24 -	LMT	1880
 # sometime between the 1994 DST switches.  Shanks & Pottenger simply say
 # 1994-09-25 03:00, but that can't be right.  For now, guess it
 # changed in May.
-			 2:00	E-Eur	EE%sT	1994 May
+			 2:00	C-Eur	EE%sT	1994 May
 # From IATA SSIM (1994/1997), which also says that Kerch is still like Kiev.
 			 3:00	E-Eur	MSK/MSD	1996 Mar 31  0:00s
 			 3:00	1:00	MSD	1996 Oct 27  3:00s
@@ -4033,6 +4051,27 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 
 # Ukraine
 #
+# From Alois Triendl (2014-03-01):
+# REGULATION A N O V A on March 20, 1992 N 139 ...  means that from
+# 1992 on, Ukraine had DST with begin time at 02:00 am, on last Sunday
+# in March, and end time 03:00 am, last Sunday in September....
+# CABINET OF MINISTERS OF UKRAINE RESOLUTION on May 13, 1996 N 509
+# "On the order of computation time on the territory of Ukraine" ....
+# As this cabinet decision is from May 1996, it seems likely that the
+# transition in March 1996, which predates it, was still at 2:00 am
+# and not at 3:00 as would have been under EU rules.
+# This is why I have set the change to EU rules into May 1996,
+# so that the change in March is stil covered by the Ukraine rule.
+# The next change in October 1996 happened under EU rules....
+# TZ database holds three other zones for Ukraine.... I have not yet
+# worked out the consequences for these three zones, as we (me and my
+# US colleague David Cochrane) are still trying to get more
+# information upon these local deviations from Kiev rules.
+#
+# From Paul Eggert (2022-02-08):
+# For now, assume that Ukraine's other three zones followed the same rules,
+# except that Crimea switched to Moscow time in 1994 as described elsewhere.
+
 # From Igor Karpov, who works for the Ukrainian Ministry of Justice,
 # via Garrett Wollman (2003-01-27):
 # BTW, I've found the official document on this matter. It's government
@@ -4122,7 +4161,7 @@ Zone Europe/Kiev	2:02:04 -	LMT	1880
 			1:00	C-Eur	CE%sT	1943 Nov  6
 			3:00	Russia	MSK/MSD	1990 Jul  1  2:00
 			2:00	1:00	EEST	1991 Sep 29  3:00
-			2:00	E-Eur	EE%sT	1995
+			2:00	C-Eur	EE%sT	1996 May 13
 			2:00	EU	EE%sT
 # Transcarpathia used CET 1990/1991.
 # "Uzhhorod" is the transliteration of the Rusyn/Ukrainian pronunciation, but
@@ -4135,8 +4174,8 @@ Zone Europe/Uzhgorod	1:29:12 -	LMT	1890 Oct
 			3:00	Russia	MSK/MSD	1990
 			3:00	-	MSK	1990 Jul  1  2:00
 			1:00	-	CET	1991 Mar 31  3:00
-			2:00	-	EET	1992
-			2:00	E-Eur	EE%sT	1995
+			2:00	-	EET	1992 Mar 20
+			2:00	C-Eur	EE%sT	1996 May 13
 			2:00	EU	EE%sT
 # Zaporozh'ye and eastern Lugansk oblasts observed DST 1990/1991.
 # "Zaporizhia" is the transliteration of the Ukrainian name, but
@@ -4149,7 +4188,8 @@ Zone Europe/Zaporozhye	2:20:40 -	LMT	1880
 			3:00	-	MSK	1941 Aug 25
 			1:00	C-Eur	CE%sT	1943 Oct 25
 			3:00	Russia	MSK/MSD	1991 Mar 31  2:00
-			2:00	E-Eur	EE%sT	1995
+			2:00	E-Eur	EE%sT	1992 Mar 20
+			2:00	C-Eur	EE%sT	1996 May 13
 			2:00	EU	EE%sT
 
 # Vatican City

--- a/make/data/tzdata/leapseconds
+++ b/make/data/tzdata/leapseconds
@@ -95,11 +95,11 @@ Leap	2016	Dec	31	23:59:60	+	S
 # Any additional leap seconds will come after this.
 # This Expires line is commented out for now,
 # so that pre-2020a zic implementations do not reject this file.
-#Expires 2022	Jun	28	00:00:00
+#Expires 2022	Dec	28	00:00:00
 
 # POSIX timestamps for the data in this file:
 #updated 1467936000 (2016-07-08 00:00:00 UTC)
-#expires 1656374400 (2022-06-28 00:00:00 UTC)
+#expires 1672185600 (2022-12-28 00:00:00 UTC)
 
-#	Updated through IERS Bulletin C62
-#	File expires on:  28 June 2022
+#	Updated through IERS Bulletin C63
+#	File expires on:  28 December 2022

--- a/make/data/tzdata/southamerica
+++ b/make/data/tzdata/southamerica
@@ -1109,7 +1109,7 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 
 # Chile
 
-# From Paul Eggert (2015-04-03):
+# From Paul Eggert (2022-03-15):
 # Shanks & Pottenger says America/Santiago introduced standard time in
 # 1890 and rounds its UT offset to 70W40; guess that in practice this
 # was the same offset as in 1916-1919.  It also says Pacific/Easter
@@ -1132,7 +1132,7 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 # Historia de la hora oficial de Chile (retrieved 2012-10-24).  See:
 # https://web.archive.org/web/20121024234627/http://www.horaoficial.cl/horaof.htm
 # A fancier Spanish version (requiring mouse-clicking) is at:
-# http://www.horaoficial.cl/historia_hora.html
+# http://www.horaoficial.cl/historia_hora.php
 # Conflicts between [1] and [2] were resolved as follows:
 #
 #  - [1] says the 1910 transition was Jan 1, [2] says Jan 10 and cites
@@ -1141,7 +1141,8 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 #  - [1] says SMT was -4:42:45, [2] says Chile's official time from
 #    1916 to 1919 was -4:42:46.3, the meridian of Chile's National
 #    Astronomical Observatory (OAN), then located in what is now
-#    Quinta Normal in Santiago.  Go with [2], rounding it to -4:42:46.
+#    Quinta Normal in Santiago.  Go with [1], as this matches the meridian
+#    referred to by the relevant Chilean laws to this day.
 #
 #  - [1] says the 1918 transition was Sep 1, [2] says Sep 10 and cites
 #    Boletín No. 22, Aviso No. 129/1918 (1918-08-23).  Go with [2].
@@ -1162,6 +1163,32 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 # Pacific/Easter is always two hours behind America/Santiago;
 # this is known to work for DST transitions starting in 2008 and
 # may well be true for earlier transitions.
+
+# From Tim Parenti (2022-03-15):
+# For a brief period of roughly six weeks in 1946, DST was only observed on an
+# emergency basis in specific regions of central Chile; namely, "the national
+# territory between the provinces of Coquimbo and Concepción, inclusive".
+# This was enacted by Decree 3,891, dated 1946-07-13, and took effect
+# 1946-07-14 24:00, advancing these central regions to -03.
+# https://www.diariooficial.interior.gob.cl/versiones-anteriores/do-h/19460715/#page/1
+# The decree contemplated "[t]hat this advancement of the Official Time, even
+# though it has been proposed for the cities of Santiago and Valparaíso only,
+# must be agreed with that of other cities, due to the connection of various
+# activities that require it, such as, for example, the operation of rail
+# services".  It was originally set to expire after 30 days but was extended
+# through 1946-08-31 by Decree 4,506, dated 1946-08-13.
+# https://www.diariooficial.interior.gob.cl/versiones-anteriores/do-h/19460814/#page/1
+#
+# Law Number 8,522, promulgated 1946-08-27, reunified Chilean clocks at their
+# new "Summer Time" of -04, reckoned as that of "the meridian of the
+# Astronomical Observatory of Lo Espejo, advanced by 42 minutes and 45
+# seconds".
+# https://www.diariooficial.interior.gob.cl/versiones-anteriores/do-h/19460828/#page/1
+# After a brief "Winter Time" stint at -05 beginning 1947-04-01, Law Number
+# 8,777, promulgated 1947-05-17, established year-round -04 "from 23:00 on the
+# second day after it is published in the 'Diario Oficial'."  It was published
+# on Monday 1947-05-19 and so took effect from Wednesday 1947-05-21 23:00.
+# https://www.diariooficial.interior.gob.cl/versiones-anteriores/do-h/19470519/#page/1
 
 # From Eduardo Krell (1995-10-19):
 # The law says to switch to DST at midnight [24:00] on the second SATURDAY
@@ -1321,12 +1348,12 @@ Rule	Chile	2019	max	-	Sep	Sun>=2	4:00u	1:00	-
 # IATA SSIM anomalies: (1992-02) says 1992-03-14;
 # (1996-09) says 1998-03-08.  Ignore these.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone America/Santiago	-4:42:46 -	LMT	1890
-			-4:42:46 -	SMT	1910 Jan 10 # Santiago Mean Time
+Zone America/Santiago	-4:42:45 -	LMT	1890
+			-4:42:45 -	SMT	1910 Jan 10 # Santiago Mean Time
 			-5:00	-	-05	1916 Jul  1
-			-4:42:46 -	SMT	1918 Sep 10
+			-4:42:45 -	SMT	1918 Sep 10
 			-4:00	-	-04	1919 Jul  1
-			-4:42:46 -	SMT	1927 Sep  1
+			-4:42:45 -	SMT	1927 Sep  1
 			-5:00	Chile	-05/-04	1932 Sep  1
 			-4:00	-	-04	1942 Jun  1
 			-5:00	-	-05	1942 Aug  1
@@ -1336,11 +1363,11 @@ Zone America/Santiago	-4:42:46 -	LMT	1890
 			-5:00	-	-05	1947 May 21 23:00
 			-4:00	Chile	-04/-03
 Zone America/Punta_Arenas -4:43:40 -	LMT	1890
-			-4:42:46 -	SMT	1910 Jan 10
+			-4:42:45 -	SMT	1910 Jan 10
 			-5:00	-	-05	1916 Jul  1
-			-4:42:46 -	SMT	1918 Sep 10
+			-4:42:45 -	SMT	1918 Sep 10
 			-4:00	-	-04	1919 Jul  1
-			-4:42:46 -	SMT	1927 Sep  1
+			-4:42:45 -	SMT	1927 Sep  1
 			-5:00	Chile	-05/-04	1932 Sep  1
 			-4:00	-	-04	1942 Jun  1
 			-5:00	-	-05	1942 Aug  1


### PR DESCRIPTION
Clean backport of [JDK-8283350](https://bugs.openjdk.java.net/browse/JDK-8283350)
(tz) Update Timezone Data to 2022a

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283350](https://bugs.openjdk.java.net/browse/JDK-8283350): (tz) Update Timezone Data to 2022a


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/52.diff">https://git.openjdk.java.net/jdk18u/pull/52.diff</a>

</details>
