### PR TITLE
8275337: C1: assert(false) failed: live_in set of first block must be empty

### DIFF
--- a/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
+++ b/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
@@ -365,7 +365,12 @@ void RangeCheckEliminator::update_bound(IntegerStack &pushed, Value v, Instructi
 bool RangeCheckEliminator::loop_invariant(BlockBegin *loop_header, Instruction *instruction) {
   assert(loop_header, "Loop header must not be null!");
   if (!instruction) return true;
-  return instruction->dominator_depth() < loop_header->dominator_depth();
+  for (BlockBegin *d = loop_header->dominator(); d != NULL; d = d->dominator()) {
+    if (d == instruction->block()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // Update bound. Pushes a new bound onto the stack. Tries to do a conjunction with the current bound.

--- a/test/hotspot/jtreg/compiler/c1/Test8275337.java
+++ b/test/hotspot/jtreg/compiler/c1/Test8275337.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8275337
+ * @run main/othervm -Xcomp -XX:TieredStopAtLevel=1 compiler.c1.Test8275337
+ */
+
+
+package compiler.c1;
+
+public class Test8275337 {
+    public static final int N = 400;
+
+    public static void mainTest() {
+        int iArr1[] = new int[N];
+        float fArr1[][] = new float[N][N];
+
+        for (int i = 9; i < 171; i++) {
+            int z;
+            try {
+                z = i % i;
+            } catch (ArithmeticException a_e) {}
+            for (int j = 1; j < 155; ++j) {
+                fArr1[j - 1][i] -= 1;
+                iArr1[i - 1] = 1;
+            }
+            for (int j = 4; j < 155; j++) {
+                for (int k = 1; k < 2; ++k) {
+                    iArr1[i - 1] += 1;
+                    fArr1[k - 1][j] -= 2;
+                }
+            }
+        }
+    }
+    public static void main(String[] strArr) {
+
+        try {
+            for (int i = 0; i < 10; i++) {
+                mainTest();
+            }
+         } catch (Exception ex) {
+         }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8275337](https://bugs.openjdk.java.net/browse/JDK-8275337). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275337](https://bugs.openjdk.java.net/browse/JDK-8275337): C1: assert(false) failed: live_in set of first block must be empty


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/57.diff">https://git.openjdk.java.net/jdk18u/pull/57.diff</a>

</details>
