### PR TITLE
8283408: Fix a C2 crash when filling arrays with unsafe

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3918,10 +3918,17 @@ bool PhaseIdealLoop::intrinsify_fill(IdealLoopTree* lpt) {
     index = new LShiftXNode(index, shift->in(2));
     _igvn.register_new_node_with_optimizer(index);
   }
-  index = new AddPNode(base, base, index);
-  _igvn.register_new_node_with_optimizer(index);
-  Node* from = new AddPNode(base, index, offset);
+  Node* from = new AddPNode(base, base, index);
   _igvn.register_new_node_with_optimizer(from);
+  // For normal array fills, C2 uses two AddP nodes for array element
+  // addressing. But for array fills with Unsafe call, there's only one
+  // AddP node adding an absolute offset, so we do a NULL check here.
+  assert(offset != NULL || C->has_unsafe_access(),
+         "Only array fills with unsafe have no extra offset");
+  if (offset != NULL) {
+    from = new AddPNode(base, from, offset);
+    _igvn.register_new_node_with_optimizer(from);
+  }
   // Compute the number of elements to copy
   Node* len = new SubINode(head->limit(), head->init_trip());
   _igvn.register_new_node_with_optimizer(len);

--- a/test/hotspot/jtreg/compiler/loopopts/FillArrayWithUnsafe.java
+++ b/test/hotspot/jtreg/compiler/loopopts/FillArrayWithUnsafe.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8283408
+ * @summary Fill a byte array with Java Unsafe API
+ * @run main/othervm -XX:+OptimizeFill compiler.loopopts.FillArrayWithUnsafe
+ */
+
+package compiler.loopopts;
+
+import java.lang.reflect.Field;
+
+import sun.misc.Unsafe;
+
+public class FillArrayWithUnsafe {
+
+    private static Unsafe unsafe;
+
+    public static void main(String[] args) throws Exception {
+        Class klass = Unsafe.class;
+        Field field = klass.getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        unsafe = (Unsafe) field.get(null);
+
+        byte[] buffer;
+        // Make sure method newByteArray is compiled by C2
+        for (int i = 0; i < 50000; i++) {
+            buffer = newByteArray(100, (byte) 0x80);
+        }
+    }
+
+    public static byte[] newByteArray(int size, byte val) {
+        byte[] arr = new byte[size];
+        int offset = unsafe.arrayBaseOffset(byte[].class);
+        for (int i = offset; i < offset + size; i++) {
+             unsafe.putByte(arr, i, val);
+        }
+        return arr;
+    }
+}
+


### PR DESCRIPTION
Backport of [JDK-8283408](https://bugs.openjdk.java.net/browse/JDK-8283408). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283408](https://bugs.openjdk.java.net/browse/JDK-8283408): Fix a C2 crash when filling arrays with unsafe


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/58.diff">https://git.openjdk.java.net/jdk18u/pull/58.diff</a>

</details>
