### PR TITLE
8282590: C2: assert(addp->is_AddP() && addp->outcnt() > 0) failed: Don't process dead nodes

### DIFF
--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -189,9 +189,8 @@ Node* ArrayCopyNode::try_clone_instance(PhaseGVN *phase, bool can_reshape, int c
   }
 
   MergeMemNode* mem = phase->transform(MergeMemNode::make(in_mem))->as_MergeMem();
-  PhaseIterGVN* igvn = phase->is_IterGVN();
-  if (igvn != NULL) {
-    igvn->_worklist.push(mem);
+  if (can_reshape) {
+    phase->is_IterGVN()->_worklist.push(mem);
   }
 
   if (!inst_src->klass_is_exact()) {
@@ -294,9 +293,17 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
     uint header = arrayOopDesc::base_offset_in_bytes(dest_elem);
 
     src_offset = Compile::conv_I2X_index(phase, src_offset, ary_src->size());
-    dest_offset = Compile::conv_I2X_index(phase, dest_offset, ary_dest->size());
-    if (src_offset->is_top() || dest_offset->is_top()) {
+    if (src_offset->is_top()) {
       // Offset is out of bounds (the ArrayCopyNode will be removed)
+      return false;
+    }
+    dest_offset = Compile::conv_I2X_index(phase, dest_offset, ary_dest->size());
+    if (dest_offset->is_top()) {
+      // Offset is out of bounds (the ArrayCopyNode will be removed)
+      if (can_reshape) {
+        // record src_offset, so it can be deleted later (if it is dead)
+        phase->is_IterGVN()->_worklist.push(src_offset);
+      }
       return false;
     }
 
@@ -316,9 +323,6 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
 
     disjoint_bases = true;
 
-    adr_src  = phase->transform(new AddPNode(base_src, base_src, src_offset));
-    adr_dest = phase->transform(new AddPNode(base_dest, base_dest, dest_offset));
-
     BasicType elem = ary_src->klass()->as_array_klass()->element_type()->basic_type();
     if (is_reference_type(elem)) {
       elem = T_OBJECT;
@@ -328,6 +332,9 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
     if (bs->array_copy_requires_gc_barriers(true, elem, true, is_clone_inst(), BarrierSetC2::Optimization)) {
       return false;
     }
+
+    adr_src  = phase->transform(new AddPNode(base_src, base_src, src_offset));
+    adr_dest = phase->transform(new AddPNode(base_dest, base_dest, dest_offset));
 
     // The address is offseted to an aligned address where a raw copy would start.
     // If the clone copy is decomposed into load-stores - the address is adjusted to
@@ -566,6 +573,8 @@ Node *ArrayCopyNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   if (!prepare_array_copy(phase, can_reshape,
                           adr_src, base_src, adr_dest, base_dest,
                           copy_type, value_type, disjoint_bases)) {
+    assert(adr_src == NULL, "no node can be left behind");
+    assert(adr_dest == NULL, "no node can be left behind");
     return NULL;
   }
 
@@ -629,6 +638,10 @@ Node *ArrayCopyNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 
   if (!finish_transform(phase, can_reshape, ctl, mem)) {
+    if (can_reshape) {
+      // put in worklist, so that if it happens to be dead it is removed
+      phase->is_IterGVN()->_worklist.push(mem);
+    }
     return NULL;
   }
 

--- a/src/hotspot/share/opto/subtypenode.cpp
+++ b/src/hotspot/share/opto/subtypenode.cpp
@@ -135,7 +135,7 @@ Node *SubTypeCheckNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     Node* obj = AddPNode::Ideal_base_and_offset(addr, phase, con);
     if (con == oopDesc::klass_offset_in_bytes() && obj != NULL) {
       assert(is_oop(phase, obj), "only for oop input");
-      set_req(ObjOrSubKlass, obj);
+      set_req_X(ObjOrSubKlass, obj, phase);
       return this;
     }
   }
@@ -144,7 +144,7 @@ Node *SubTypeCheckNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   Node* allocated_klass = AllocateNode::Ideal_klass(obj_or_subklass, phase);
   if (allocated_klass != NULL) {
     assert(is_oop(phase, obj_or_subklass), "only for oop input");
-    set_req(ObjOrSubKlass, allocated_klass);
+    set_req_X(ObjOrSubKlass, allocated_klass, phase);
     return this;
   }
 

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyAsLoadsStores.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyAsLoadsStores.java
@@ -38,6 +38,19 @@
  *                   compiler.arraycopy.TestArrayCopyAsLoadsStores
  */
 
+/*
+ * @test
+ * @bug 8282590
+ * @library /
+ *
+ * @run main/othervm -ea -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
+ *                   -XX:CompileCommand=dontinline,compiler.arraycopy.TestArrayCopyAsLoadsStores::m*
+ *                   -XX:TypeProfileLevel=200
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+StressArrayCopyMacroNode
+ *                   -XX:-TieredCompilation -XX:+StressReflectiveCode -XX:-ReduceInitialCardMarks
+ *                   compiler.arraycopy.TestArrayCopyAsLoadsStores
+ */
+
 package compiler.arraycopy;
 
 import java.util.Arrays;


### PR DESCRIPTION
Backport of [JDK-8282590](https://bugs.openjdk.java.net/browse/JDK-8282590). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282590](https://bugs.openjdk.java.net/browse/JDK-8282590): C2: assert(addp->is_AddP() && addp->outcnt() > 0) failed: Don't process dead nodes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/59.diff">https://git.openjdk.java.net/jdk18u/pull/59.diff</a>

</details>
