### PR TITLE
8283451: C2: assert(_base == Long) failed: Not a Long

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1691,7 +1691,7 @@ bool PhaseIterGVN::no_dependent_zero_check(Node* n) const {
     case Op_DivI:
     case Op_ModI: {
       // Type of divisor includes 0?
-      if (n->in(2)->is_top()) {
+      if (type(n->in(2)) == Type::TOP) {
         // 'n' is dead. Treat as if zero check is still there to avoid any further optimizations.
         return false;
       }
@@ -1701,7 +1701,7 @@ bool PhaseIterGVN::no_dependent_zero_check(Node* n) const {
     case Op_DivL:
     case Op_ModL: {
       // Type of divisor includes 0?
-      if (n->in(2)->is_top()) {
+      if (type(n->in(2)) == Type::TOP) {
         // 'n' is dead. Treat as if zero check is still there to avoid any further optimizations.
         return false;
       }

--- a/test/hotspot/jtreg/compiler/c2/TestModDivTopInput.java
+++ b/test/hotspot/jtreg/compiler/c2/TestModDivTopInput.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8283451
+ * @summary C2: assert(_base == Long) failed: Not a Long
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressLCM -XX:+StressGCM -XX:+StressCCP -XX:+StressIGVN
+ *                   -Xcomp -XX:CompileOnly=TestModDivTopInput -XX:-TieredCompilation -XX:StressSeed=87628618 TestModDivTopInput
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressLCM -XX:+StressGCM -XX:+StressCCP -XX:+StressIGVN
+ *                   -Xcomp -XX:CompileOnly=TestModDivTopInput -XX:-TieredCompilation TestModDivTopInput
+ */
+
+public class TestModDivTopInput {
+
+    public static final int N = 400;
+
+    public static float fFld=-2.447F;
+    public long lFld=-189L;
+
+    public void mainTest(String[] strArr1) {
+
+        int i18, i20=-14, i21, iArr2[]=new int[N];
+        boolean b2=true;
+        double d2;
+        long l;
+
+        init(iArr2, -13265);
+
+        for (i18 = 13; i18 < 315; ++i18) {
+            if (b2) continue;
+            for (d2 = 5; d2 < 83; d2++) {
+            }
+            for (i21 = 4; i21 < 83; i21++) {
+                for (l = 1; 2 > l; l++) {
+                }
+                b2 = b2;
+                lFld %= (i20 | 1);
+                i20 = (int)fFld;
+                i20 += (int)d2;
+            }
+        }
+    }
+
+    public static void main(String[] strArr) {
+        TestModDivTopInput _instance = new TestModDivTopInput();
+        for (int i = 0; i < 10; i++ ) {
+            _instance.mainTest(strArr);
+        }
+    }
+
+    static void init(int[] arr, int v) {
+        for (int i = 0; i < arr.length; i++) {
+            arr[i] = v;
+        }
+    }
+
+}


### PR DESCRIPTION
Backport of [JDK-8283451](https://bugs.openjdk.java.net/browse/JDK-8283451). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283451](https://bugs.openjdk.java.net/browse/JDK-8283451): C2: assert(_base == Long) failed: Not a Long


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/60.diff">https://git.openjdk.java.net/jdk18u/pull/60.diff</a>

</details>
