### PR TITLE
8277055: Assert "missing inlining msg" with -XX:+PrintIntrinsics

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -526,12 +526,20 @@ bool LateInlineVirtualCallGenerator::do_late_inline_check(Compile* C, JVMState* 
   Node* receiver = jvms->map()->argument(jvms, 0);
   const Type* recv_type = C->initial_gvn()->type(receiver);
   if (recv_type->maybe_null()) {
+    if (C->print_inlining() || C->print_intrinsics()) {
+      C->print_inlining(method(), jvms->depth()-1, call_node()->jvms()->bci(),
+                        "late call devirtualization failed (receiver may be null)");
+    }
     return false;
   }
   // Even if inlining is not allowed, a virtual call can be strength-reduced to a direct call.
   bool allow_inline = C->inlining_incrementally();
   if (!allow_inline && _callee->holder()->is_interface()) {
     // Don't convert the interface call to a direct call guarded by an interface subtype check.
+    if (C->print_inlining() || C->print_intrinsics()) {
+      C->print_inlining(method(), jvms->depth()-1, call_node()->jvms()->bci(),
+                        "late call devirtualization failed (interface call)");
+    }
     return false;
   }
   CallGenerator* cg = C->call_generator(_callee,

--- a/test/hotspot/jtreg/compiler/print/PrintInlining.java
+++ b/test/hotspot/jtreg/compiler/print/PrintInlining.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,14 @@
 
 /*
  * @test
- * @bug 8022585
+ * @bug 8022585 8277055
  * @summary VM crashes when ran with -XX:+PrintInlining
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining
  *                   compiler.print.PrintInlining
- *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining
+ *                   compiler.print.PrintInlining
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+PrintIntrinsics
+ *                   compiler.print.PrintInlining
  */
 
 package compiler.print;


### PR DESCRIPTION
Backport of [JDK-8277055](https://bugs.openjdk.java.net/browse/JDK-8277055). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277055](https://bugs.openjdk.java.net/browse/JDK-8277055): Assert "missing inlining msg" with -XX:+PrintIntrinsics


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/63.diff">https://git.openjdk.java.net/jdk18u/pull/63.diff</a>

</details>
