### PR TITLE
8281544: assert(VM_Version::supports_avx512bw()) failed for Tests jdk/incubator/vector/

### DIFF
--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -452,7 +452,7 @@ private:
 
   void opmask_register_save(KRegister reg) {
     _spill_offset -= 8;
-    __ kmovql(Address(rsp, _spill_offset), reg);
+    __ kmov(Address(rsp, _spill_offset), reg);
   }
 
   void gp_register_restore(Register reg) {
@@ -461,7 +461,7 @@ private:
   }
 
   void opmask_register_restore(KRegister reg) {
-    __ kmovql(reg, Address(rsp, _spill_offset));
+    __ kmov(reg, Address(rsp, _spill_offset));
     _spill_offset += 8;
   }
 

--- a/test/jdk/jdk/incubator/vector/VectorMaxConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/VectorMaxConversionTests.java
@@ -40,6 +40,18 @@ import java.util.List;
  * VectorMaxConversionTests
  */
 
+/*
+ * @test
+ * @bug 8281544
+ * @summary Test that ZGC and vectorapi with KNL work together.
+ * @requires vm.gc.Z
+ * @modules jdk.incubator.vector
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ *                      -XX:+UnlockDiagnosticVMOptions -XX:+UseKNLSetting -XX:+UseZGC -XX:+IgnoreUnrecognizedVMOptions
+ *                      VectorMaxConversionTests
+ */
+
 @Test
 public class VectorMaxConversionTests extends AbstractVectorConversionTest {
 


### PR DESCRIPTION
Backport of [JDK-8281544](https://bugs.openjdk.java.net/browse/JDK-8281544). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281544](https://bugs.openjdk.java.net/browse/JDK-8281544): assert(VM_Version::supports_avx512bw()) failed for Tests jdk/incubator/vector/


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/66.diff">https://git.openjdk.java.net/jdk18u/pull/66.diff</a>

</details>
