### PR TITLE
8280600: C2: assert(!had_error) failed: bad dominance

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1222,7 +1222,7 @@ Node *PhaseIdealLoop::clone_up_backedge_goo(Node *back_ctrl, Node *preheader_ctr
 }
 
 Node* PhaseIdealLoop::cast_incr_before_loop(Node* incr, Node* ctrl, Node* loop) {
-  Node* castii = new CastIINode(incr, TypeInt::INT, ConstraintCastNode::StrongDependency);
+  Node* castii = new CastIINode(incr, TypeInt::INT, ConstraintCastNode::UnconditionalDependency);
   castii->set_req(0, ctrl);
   register_new_node(castii, ctrl);
   for (DUIterator_Fast imax, i = incr->fast_outs(imax); i < imax; i++) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestCastIIMakesMainLoopPhiDead.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCastIIMakesMainLoopPhiDead.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * bug 8280600
+ * @summary C2: assert(!had_error) failed: bad dominance
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestCastIIMakesMainLoopPhiDead TestCastIIMakesMainLoopPhiDead
+ */
+
+public class TestCastIIMakesMainLoopPhiDead {
+    int iArr[] = new int[0];
+
+    void test() {
+        int x = 8;
+        try {
+            for (int i = 0; i < 8; i++) {
+                iArr[1] = 9;
+                for (int j = -400; 1 > j; j++) {
+                    iArr[j] = 4;
+                    x -= 2;
+                }
+            }
+        } catch (ArrayIndexOutOfBoundsException e) {
+        }
+    }
+    public static void main(String[] k) {
+        TestCastIIMakesMainLoopPhiDead t = new TestCastIIMakesMainLoopPhiDead();
+        for (int i = 0; i < 3; i++) {
+            t.test();
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8280600](https://bugs.openjdk.java.net/browse/JDK-8280600). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280600](https://bugs.openjdk.java.net/browse/JDK-8280600): C2: assert(!had_error) failed: bad dominance


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/68.diff">https://git.openjdk.java.net/jdk18u/pull/68.diff</a>

</details>
