### PR TITLE
8281274: deal with ActiveProcessorCount in os::Linux::print_container_info

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2174,7 +2174,11 @@ bool os::Linux::print_container_info(outputStream* st) {
   int i = OSContainer::active_processor_count();
   st->print("active_processor_count: ");
   if (i > 0) {
-    st->print_cr("%d", i);
+    if (ActiveProcessorCount > 0) {
+      st->print_cr("%d, but overridden by -XX:ActiveProcessorCount %d", i, ActiveProcessorCount);
+    } else {
+      st->print_cr("%d", i);
+    }
   } else {
     st->print_cr("not supported");
   }

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@ public class TestMisc {
             testMinusContainerSupport();
             testIsContainerized();
             testPrintContainerInfo();
+            testPrintContainerInfoActiveProcessorCount();
         } finally {
             DockerTestUtils.removeDockerImage(imageName);
         }
@@ -92,6 +93,15 @@ public class TestMisc {
         checkContainerInfo(Common.run(opts));
     }
 
+    private static void testPrintContainerInfoActiveProcessorCount() throws Exception {
+        Common.logNewTestCase("Test print_container_info()");
+
+        DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo").addJavaOpts("-XX:ActiveProcessorCount=2");
+        Common.addWhiteBoxOpts(opts);
+
+        OutputAnalyzer out = Common.run(opts);
+        out.shouldContain("but overridden by -XX:ActiveProcessorCount 2");
+    }
 
     private static void checkContainerInfo(OutputAnalyzer out) throws Exception {
         String[] expectedToContain = new String[] {


### PR DESCRIPTION
Backport of the fix for JDK-82821274 to JDK-18u.   The patch applied cleanly and was tested with Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows and Mach5 tiers 3-5 on Linux x64.
Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281274](https://bugs.openjdk.java.net/browse/JDK-8281274): deal with ActiveProcessorCount in os::Linux::print_container_info


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/75.diff">https://git.openjdk.java.net/jdk18u/pull/75.diff</a>

</details>
