### PR TITLE
8281181: Do not use CPU Shares to compute active processor count

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -495,7 +495,10 @@ int CgroupSubsystem::active_processor_count() {
   cpu_count = limit_count = os::Linux::active_processor_count();
   int quota  = cpu_quota();
   int period = cpu_period();
-  int share  = cpu_shares();
+
+  // It's not a good idea to use cpu_shares() to limit the number
+  // of CPUs used by the JVM. See JDK-8281181.
+  int share  = UseContainerCpuShares ? cpu_shares() : -1;
 
   if (quota > -1 && period > 0) {
     quota_count = ceilf((float)quota / (float)period);

--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,10 @@
                                                                         \
   product(bool, UseContainerSupport, true,                              \
           "Enable detection and runtime container configuration support") \
+                                                                        \
+  product(bool, UseContainerCpuShares, false,                           \
+          "Include CPU shares in the CPU availability"                  \
+          " calculation.")                                              \
                                                                         \
   product(bool, PreferContainerQuotaForCPUCount, true,                  \
           "Calculate the container CPU availability based on the value" \

--- a/test/hotspot/jtreg/containers/cgroup/PlainRead.java
+++ b/test/hotspot/jtreg/containers/cgroup/PlainRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class PlainRead {
     static final String good_value = "(\\d+|-1|-2|Unlimited)";
     static final String bad_value = "(failed)";
 
-    static final String[] variables = {"Memory Limit is:", "CPU Shares is:", "CPU Quota is:", "CPU Period is:", "active_processor_count:"};
+    static final String[] variables = {"Memory Limit is:", "CPU Quota is:", "CPU Period is:", "active_processor_count:"};
 
     static public void isContainer(OutputAnalyzer oa) {
         for (String v: variables) {

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,6 +100,11 @@ public class TestCPUAwareness {
         String cpuSetStr = CPUSetsReader.readFromProcStatus("Cpus_allowed_list");
         System.out.println("cpuSetStr = " + cpuSetStr);
 
+        // OLD = use the -XX:+UseContainerCpuShares flag, which
+        // may be removed in a future JDK release. See JDK-8281181.
+        boolean OLD = true;
+        boolean NEW = false;
+
         if (cpuSetStr == null) {
             System.out.printf("The cpuset test cases are skipped");
         } else {
@@ -108,23 +113,32 @@ public class TestCPUAwareness {
             // Test subset of cpuset with one element
             if (cpuSet.size() >= 1) {
                 String testCpuSet = CPUSetsReader.listToString(cpuSet, 1);
-                testAPCCombo(testCpuSet, 200*1000, 100*1000,   4*1024, true, 1);
+                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000,   4*1024, true, 1);
+                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000,   4*1024, true, 1);
             }
 
             // Test subset of cpuset with two elements
             if (cpuSet.size() >= 2) {
                 String testCpuSet = CPUSetsReader.listToString(cpuSet, 2);
-                testAPCCombo(testCpuSet, 200*1000, 100*1000, 4*1024, true, 2);
-                testAPCCombo(testCpuSet, 200*1000, 100*1000, 1023,   true, 2);
-                testAPCCombo(testCpuSet, 200*1000, 100*1000, 1023,   false,  1);
+                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000, 4*1024, true, 2);
+                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000, 1023,   true, 2);
+                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000, 1023,   false,1);
+
+                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000, 4*1024, true, 2);
+                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000, 1023,   true, 2);
+                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000, 1023,   false,2);
             }
 
             // Test subset of cpuset with three elements
             if (cpuSet.size() >= 3) {
                 String testCpuSet = CPUSetsReader.listToString(cpuSet, 3);
-                testAPCCombo(testCpuSet, 100*1000, 100*1000, 2*1024, true, 1);
-                testAPCCombo(testCpuSet, 200*1000, 100*1000, 1023,   true, 2);
-                testAPCCombo(testCpuSet, 200*1000, 100*1000, 1023,   false,  1);
+                testAPCCombo(OLD, testCpuSet, 100*1000, 100*1000, 2*1024, true, 1);
+                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000, 1023,   true, 2);
+                testAPCCombo(OLD, testCpuSet, 200*1000, 100*1000, 1023,   false,1);
+
+                testAPCCombo(NEW, testCpuSet, 100*1000, 100*1000, 2*1024, true, 1);
+                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000, 1023,   true, 2);
+                testAPCCombo(NEW, testCpuSet, 200*1000, 100*1000, 1023,   false,2);
             }
         }
     }
@@ -181,8 +195,11 @@ public class TestCPUAwareness {
     }
 
 
-    // Test correctess of automatically selected active processor cound
-    private static void testAPCCombo(String cpuset, int quota, int period, int shares,
+    // Test correctess of automatically selected active processor count
+    // Note: when -XX:+UseContainerCpuShares is removed,
+    // useContainerCpuShares, shares, and usePreferContainerQuotaForCPUCount
+    // should also be removed.
+    private static void testAPCCombo(boolean useContainerCpuShares, String cpuset, int quota, int period, int shares,
                                      boolean usePreferContainerQuotaForCPUCount,
                                      int expectedAPC) throws Exception {
         Common.logNewTestCase("test APC Combo");
@@ -190,6 +207,7 @@ public class TestCPUAwareness {
         System.out.println("quota = " + quota);
         System.out.println("period = " + period);
         System.out.println("shares = " + shares);
+        System.out.println("useContainerCpuShares = " + useContainerCpuShares);
         System.out.println("usePreferContainerQuotaForCPUCount = " + usePreferContainerQuotaForCPUCount);
         System.out.println("expectedAPC = " + expectedAPC);
 
@@ -201,6 +219,7 @@ public class TestCPUAwareness {
             .addDockerOpts("--cpu-quota=" + quota)
             .addDockerOpts("--cpu-shares=" + shares);
 
+        if (useContainerCpuShares) opts.addJavaOpts("-XX:+UseContainerCpuShares");
         if (!usePreferContainerQuotaForCPUCount) opts.addJavaOpts("-XX:-PreferContainerQuotaForCPUCount");
 
         Common.run(opts)
@@ -208,6 +227,7 @@ public class TestCPUAwareness {
     }
 
 
+    // Note: when -XX:+UseContainerCpuShares is removed, this test should also be removed.
     private static void testCpuShares(int shares, int expectedAPC) throws Exception {
         Common.logNewTestCase("test cpu shares, shares = " + shares);
         System.out.println("expectedAPC = " + expectedAPC);
@@ -216,6 +236,7 @@ public class TestCPUAwareness {
 
         DockerRunOptions opts = Common.newOpts(imageName)
             .addDockerOpts("--cpu-shares=" + shares);
+        opts.addJavaOpts("-XX:+UseContainerCpuShares");
         OutputAnalyzer out = Common.run(opts);
         // Cgroups v2 needs to do some scaling of raw shares values. Hence,
         // 256 CPU shares come back as 264. Raw value written to cpu.weight


### PR DESCRIPTION
Please review this backport of [JDK-8281181](https://bugs.openjdk.java.net/browse/JDK-8281181) to jdk18u. Most changes were cleanly applied, except:

- The changes in related to the deprecation of UseContainerCpuShares and PreferContainerQuotaForCPUCount) have been dropped. That's because the deprecation happens in the JDK 19 release cycle, not in 18u.

You can compare with the JDK 19 version of the changes [here](https://github.com/openjdk/jdk/pull/7666/files).

Tested with tiers 1-5, including all container test tasks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8281181](https://bugs.openjdk.java.net/browse/JDK-8281181): Do not use CPU Shares to compute active processor count
 * [JDK-8281571](https://bugs.openjdk.java.net/browse/JDK-8281571): Do not use CPU Shares to compute active processor count (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/79.diff">https://git.openjdk.java.net/jdk18u/pull/79.diff</a>

</details>
