### PR TITLE
8279822: CI: Constant pool entries in error state are not supported

### DIFF
--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -416,11 +416,11 @@ void BCEscapeAnalyzer::iterate_one_block(ciBlock *blk, StateInfo &state, Growabl
         // Avoid calling get_constant() which will try to allocate
         // unloaded constant. We need only constant's type.
         int index = s.get_constant_pool_index();
-        constantTag tag = s.get_constant_pool_tag(index);
-        if (tag.is_long() || tag.is_double()) {
+        BasicType con_bt = s.get_basic_type_for_constant_at(index);
+        if (con_bt == T_LONG || con_bt == T_DOUBLE) {
           // Only longs and doubles use 2 stack slots.
           state.lpush();
-        } else if (tag.basic_type() == T_OBJECT) {
+        } else if (con_bt == T_OBJECT) {
           state.apush(unknown_obj);
         } else {
           state.spush();

--- a/src/hotspot/share/ci/ciConstant.hpp
+++ b/src/hotspot/share/ci/ciConstant.hpp
@@ -127,6 +127,17 @@ public:
   bool is_valid() const {
     return basic_type() != T_ILLEGAL;
   }
+
+  bool is_loaded() const {
+    if (is_valid()) {
+      if (is_reference_type(basic_type())) {
+        return as_object()->is_loaded();
+      } else {
+        return true;
+      }
+    }
+    return false;
+  }
   // Debugging output
   void print();
 };

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -503,13 +503,6 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
     domain = Handle(current, accessing_klass->protection_domain());
   }
 
-  // setup up the proper type to return on OOM
-  ciKlass* fail_type;
-  if (sym->char_at(0) == JVM_SIGNATURE_ARRAY) {
-    fail_type = _unloaded_ciobjarrayklass;
-  } else {
-    fail_type = _unloaded_ciinstance_klass;
-  }
   Klass* found_klass;
   {
     ttyUnlocker ttyul;  // release tty lock to avoid ordering problems
@@ -591,7 +584,6 @@ ciKlass* ciEnv::get_klass_by_index_impl(const constantPoolHandle& cpool,
                                         int index,
                                         bool& is_accessible,
                                         ciInstanceKlass* accessor) {
-  EXCEPTION_CONTEXT;
   Klass* klass = NULL;
   Symbol* klass_name = NULL;
 
@@ -599,7 +591,7 @@ ciKlass* ciEnv::get_klass_by_index_impl(const constantPoolHandle& cpool,
     klass_name = cpool->symbol_at(index);
   } else {
     // Check if it's resolved if it's not a symbol constant pool entry.
-    klass =  ConstantPool::klass_at_if_loaded(cpool, index);
+    klass = ConstantPool::klass_at_if_loaded(cpool, index);
     // Try to look it up by name.
     if (klass == NULL) {
       klass_name = cpool->klass_name_at(index);
@@ -666,7 +658,6 @@ ciConstant ciEnv::get_constant_by_index_impl(const constantPoolHandle& cpool,
                                              int pool_index, int cache_index,
                                              ciInstanceKlass* accessor) {
   bool ignore_will_link;
-  EXCEPTION_CONTEXT;
   int index = pool_index;
   if (cache_index >= 0) {
     assert(index < 0, "only one kind of index at a time");
@@ -677,12 +668,14 @@ ciConstant ciEnv::get_constant_by_index_impl(const constantPoolHandle& cpool,
         return ciConstant(T_OBJECT, get_object(NULL));
       }
       BasicType bt = T_OBJECT;
-      if (cpool->tag_at(index).is_dynamic_constant())
+      if (cpool->tag_at(index).is_dynamic_constant()) {
         bt = Signature::basic_type(cpool->uncached_signature_ref_at(index));
-      if (is_reference_type(bt)) {
-      } else {
+      }
+      if (!is_reference_type(bt)) {
         // we have to unbox the primitive value
-        if (!is_java_primitive(bt))  return ciConstant();
+        if (!is_java_primitive(bt)) {
+          return ciConstant();
+        }
         jvalue value;
         BasicType bt2 = java_lang_boxing_object::get_value(obj, &value);
         assert(bt2 == bt, "");
@@ -717,6 +710,7 @@ ciConstant ciEnv::get_constant_by_index_impl(const constantPoolHandle& cpool,
   } else if (tag.is_double()) {
     return ciConstant((jdouble)cpool->double_at(index));
   } else if (tag.is_string()) {
+    EXCEPTION_CONTEXT;
     oop string = NULL;
     assert(cache_index >= 0, "should have a cache index");
     string = cpool->string_at(index, cache_index, THREAD);
@@ -733,24 +727,18 @@ ciConstant ciEnv::get_constant_by_index_impl(const constantPoolHandle& cpool,
       return ciConstant(T_OBJECT, constant);
     }
   } else if (tag.is_unresolved_klass_in_error()) {
-    return ciConstant();
+    return ciConstant(T_OBJECT, get_unloaded_klass_mirror(NULL));
   } else if (tag.is_klass() || tag.is_unresolved_klass()) {
-    // 4881222: allow ldc to take a class type
     ciKlass* klass = get_klass_by_index_impl(cpool, index, ignore_will_link, accessor);
-    if (HAS_PENDING_EXCEPTION) {
-      CLEAR_PENDING_EXCEPTION;
-      record_out_of_memory_failure();
-      return ciConstant();
-    }
     assert (klass->is_instance_klass() || klass->is_array_klass(),
             "must be an instance or array klass ");
     return ciConstant(T_OBJECT, klass->java_mirror());
-  } else if (tag.is_method_type()) {
+  } else if (tag.is_method_type() || tag.is_method_type_in_error()) {
     // must execute Java code to link this CP entry into cache[i].f1
     ciSymbol* signature = get_symbol(cpool->method_type_signature_at(index));
     ciObject* ciobj = get_unloaded_method_type_constant(signature);
     return ciConstant(T_OBJECT, ciobj);
-  } else if (tag.is_method_handle()) {
+  } else if (tag.is_method_handle() || tag.is_method_handle_in_error()) {
     // must execute Java code to link this CP entry into cache[i].f1
     int ref_kind        = cpool->method_handle_ref_kind_at(index);
     int callee_index    = cpool->method_handle_klass_index_at(index);
@@ -759,10 +747,10 @@ ciConstant ciEnv::get_constant_by_index_impl(const constantPoolHandle& cpool,
     ciSymbol* signature = get_symbol(cpool->method_handle_signature_ref_at(index));
     ciObject* ciobj     = get_unloaded_method_handle_constant(callee, name, signature, ref_kind);
     return ciConstant(T_OBJECT, ciobj);
-  } else if (tag.is_dynamic_constant()) {
-    return ciConstant();
+  } else if (tag.is_dynamic_constant() || tag.is_dynamic_constant_in_error()) {
+    return ciConstant(); // not supported
   } else {
-    ShouldNotReachHere();
+    assert(false, "unknown tag: %d (%s)", tag.value(), tag.internal_name());
     return ciConstant();
   }
 }

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -252,6 +252,14 @@ constantTag ciBytecodeStream::get_constant_pool_tag(int index) const {
 }
 
 // ------------------------------------------------------------------
+// ciBytecodeStream::get_basic_type_for_constant_at
+//
+BasicType ciBytecodeStream::get_basic_type_for_constant_at(int index) const {
+  VM_ENTRY_MARK;
+  return _method->get_Method()->constants()->basic_type_for_constant_at(index);
+}
+
+// ------------------------------------------------------------------
 // ciBytecodeStream::get_field_index
 //
 // If this is a field access bytecode, get the constant pool

--- a/src/hotspot/share/ci/ciStreams.hpp
+++ b/src/hotspot/share/ci/ciStreams.hpp
@@ -140,7 +140,7 @@ public:
 
   bool is_wide() const { return ( _pc == _was_wide ); }
 
-  // Does this instruction contain an index which refes into the CP cache?
+  // Does this instruction contain an index which refers into the CP cache?
   bool has_cache_index() const { return Bytecodes::uses_cp_cache(cur_bc_raw()); }
 
   int get_index_u1() const {
@@ -226,8 +226,9 @@ public:
   // constant.  Do not attempt to resolve it, since that would require
   // execution of Java code.  If it is not resolved, return an unloaded
   // object (ciConstant.as_object()->is_loaded() == false).
-  ciConstant get_constant();
+  ciConstant  get_constant();
   constantTag get_constant_pool_tag(int index) const;
+  BasicType   get_basic_type_for_constant_at(int index) const;
 
   // True if the klass-using bytecode points to an unresolved klass
   bool is_unresolved_klass() const {
@@ -235,9 +236,17 @@ public:
     return tag.is_unresolved_klass();
   }
 
-  bool is_unresolved_klass_in_error() const {
-    constantTag tag = get_constant_pool_tag(get_klass_index());
-    return tag.is_unresolved_klass_in_error();
+  bool is_in_error() const {
+    assert(cur_bc() == Bytecodes::_ldc    ||
+           cur_bc() == Bytecodes::_ldc_w  ||
+           cur_bc() == Bytecodes::_ldc2_w, "not supported: %s", Bytecodes::name(cur_bc()));
+
+    int index = get_constant_pool_index();
+    constantTag tag = get_constant_pool_tag(index);
+    return tag.is_unresolved_klass_in_error() ||
+           tag.is_method_handle_in_error()    ||
+           tag.is_method_type_in_error()      ||
+           tag.is_dynamic_constant_in_error();
   }
 
   // If this bytecode is one of get_field, get_static, put_field,

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -720,6 +720,11 @@ void ciTypeFlow::StateVector::do_jsr(ciBytecodeStream* str) {
 // ------------------------------------------------------------------
 // ciTypeFlow::StateVector::do_ldc
 void ciTypeFlow::StateVector::do_ldc(ciBytecodeStream* str) {
+  if (str->is_in_error()) {
+    trap(str, NULL, Deoptimization::make_trap_request(Deoptimization::Reason_unhandled,
+                                                      Deoptimization::Action_none));
+    return;
+  }
   ciConstant con = str->get_constant();
   if (con.is_valid()) {
     BasicType basic_type = con.basic_type();
@@ -735,14 +740,10 @@ void ciTypeFlow::StateVector::do_ldc(ciBytecodeStream* str) {
       push_translate(ciType::make(basic_type));
     }
   } else {
-    if (str->is_unresolved_klass_in_error()) {
-      trap(str, NULL, Deoptimization::make_trap_request(Deoptimization::Reason_unhandled,
-                                                        Deoptimization::Action_none));
-    } else {
-      // OutOfMemoryError in the CI while loading constant
-      push_null();
-      outer()->record_failure("ldc did not link");
-    }
+    // OutOfMemoryError in the CI while loading constant.
+    // Unresolved condy also lands here (not yet supported).
+    push_null();
+    outer()->record_failure("ldc did not link");
   }
 }
 
@@ -2173,7 +2174,7 @@ bool ciTypeFlow::can_trap(ciBytecodeStream& str) {
     case Bytecodes::_ldc:
     case Bytecodes::_ldc_w:
     case Bytecodes::_ldc2_w:
-      return str.is_unresolved_klass_in_error();
+      return str.is_in_error();
 
     case Bytecodes::_aload_0:
       // These bytecodes can trap for rewriting.  We need to assume that

--- a/src/hotspot/share/utilities/constantTag.hpp
+++ b/src/hotspot/share/utilities/constantTag.hpp
@@ -86,6 +86,13 @@ class constantTag {
     return _tag == JVM_CONSTANT_DynamicInError;
   }
 
+  bool is_in_error() const {
+    return is_unresolved_klass_in_error() ||
+           is_method_handle_in_error()    ||
+           is_method_type_in_error()      ||
+           is_dynamic_constant_in_error();
+  }
+
   bool is_klass_index() const       { return _tag == JVM_CONSTANT_ClassIndex; }
   bool is_string_index() const      { return _tag == JVM_CONSTANT_StringIndex; }
 
@@ -121,18 +128,24 @@ class constantTag {
     _tag = tag;
   }
 
-  static constantTag ofBasicType(BasicType bt) {
-    if (is_subword_type(bt))  bt = T_INT;
-    switch (bt) {
-      case T_OBJECT: return constantTag(JVM_CONSTANT_String);
-      case T_INT:    return constantTag(JVM_CONSTANT_Integer);
-      case T_LONG:   return constantTag(JVM_CONSTANT_Long);
-      case T_FLOAT:  return constantTag(JVM_CONSTANT_Float);
-      case T_DOUBLE: return constantTag(JVM_CONSTANT_Double);
-      default:       break;
+  static jbyte type2tag(BasicType bt) {
+    if (is_subword_type(bt)) {
+      bt = T_INT;
     }
-    assert(false, "bad basic type for tag");
-    return constantTag();
+    if (bt == T_ARRAY) {
+      bt = T_OBJECT;
+    }
+    switch (bt) {
+      case T_INT:    return JVM_CONSTANT_Integer;
+      case T_LONG:   return JVM_CONSTANT_Long;
+      case T_FLOAT:  return JVM_CONSTANT_Float;
+      case T_DOUBLE: return JVM_CONSTANT_Double;
+      case T_OBJECT: return JVM_CONSTANT_String;
+
+      default:
+        assert(false, "not supported: %s", type2name(bt));
+        return JVM_CONSTANT_Invalid;
+    }
   }
 
   jbyte value() const                { return _tag; }

--- a/test/hotspot/jtreg/compiler/runtime/TestConstantsInError.java
+++ b/test/hotspot/jtreg/compiler/runtime/TestConstantsInError.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8279822
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *
+ * @run main compiler.runtime.TestConstantsInError
+ */
+package compiler.runtime;
+
+import jdk.internal.org.objectweb.asm.*;
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandleProxies;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
+
+import static jdk.internal.org.objectweb.asm.ClassWriter.*;
+import static jdk.internal.org.objectweb.asm.Opcodes.*;
+
+interface OutputProcessor {
+    default void process(OutputAnalyzer output, boolean isC1) {}
+}
+
+public abstract class TestConstantsInError implements OutputProcessor {
+    static final String TEST_PREFIX = class2desc(TestConstantsInError.class) + "$Test";
+
+    public interface Test extends Runnable {}
+
+
+    interface Generator {
+        void generate(MethodVisitor mv);
+    }
+
+    static String class2desc(Class<?> cls) {
+        return cls.getName().replace('.', '/');
+    }
+
+    public static final String PATH = System.getProperty("test.classes", ".") + java.io.File.separator;
+
+    static byte[] generateClassFile(String suffix, Generator g) throws IOException {
+        var cw = new ClassWriter(COMPUTE_MAXS | COMPUTE_FRAMES);
+        String name = TEST_PREFIX + "_" + suffix;
+        cw.visit(V19, ACC_PUBLIC | ACC_SUPER, name, null, "java/lang/Object", null);
+
+        {
+            var mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "test", "()V", null, null);
+            mv.visitCode();
+            g.generate(mv);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(0, 0);
+        }
+        byte[] classFile = cw.toByteArray();
+
+        try (FileOutputStream fos = new FileOutputStream(PATH + name + ".class")) {
+            fos.write(classFile);
+        }
+
+        return classFile;
+    }
+
+    static Test generate(String suffix, Class<? extends LinkageError> expectedError, Generator g) {
+        try {
+            byte[] classFile = generateClassFile(suffix, g);
+            MethodHandles.Lookup testLookup = MethodHandles.lookup().defineHiddenClass(classFile, true);
+            MethodHandle testMH = testLookup.findStatic(testLookup.lookupClass(), "test", MethodType.methodType(void.class));
+
+            testMH = MethodHandles.filterReturnValue(testMH,
+                    MethodHandles.insertArguments(
+                            MethodHandles.throwException(void.class, AssertionError.class),
+                            0, new AssertionError("no exception thrown")));
+
+            // Install empty handler for linkage exceptions.
+            testMH = MethodHandles.catchException(testMH, expectedError,
+                     MethodHandles.empty(MethodType.methodType(void.class, expectedError)));
+
+            return MethodHandleProxies.asInterfaceInstance(Test.class, testMH);
+        } catch (Throwable e) {
+            throw new InternalError(e);
+        }
+    }
+
+    static void run(String name, Class<? extends LinkageError> expectedError, Generator g) {
+        Test test = generate(name, expectedError, g);
+        for (int i = 0; i < 1000; i++) {
+            test.run();
+        }
+    }
+
+    static class TestConstantClass extends TestConstantsInError {
+        public static void main(String[] args) {
+            run("C1", NoClassDefFoundError.class, mv -> mv.visitLdcInsn(Type.getType("LUnknownClass;")));                // non-existent class
+            run("C2",   IllegalAccessError.class, mv -> mv.visitLdcInsn(Type.getType("Ljava/lang/invoke/LambdaForm;"))); // inaccessible
+
+            // class loader constraints?
+        }
+
+        public void process(OutputAnalyzer results, boolean isC1) {
+            results.shouldMatch("Test_C1/.*::test \\(3 bytes\\)$")
+                   .shouldMatch("Test_C2/.*::test \\(3 bytes\\)$");
+
+            if (isC1 && Platform.isAArch64()) { // no code patching
+                results.shouldMatch("Test_C1/.*::test \\(3 bytes\\)   made not entrant")
+                       .shouldMatch("Test_C2/.*::test \\(3 bytes\\)   made not entrant");
+            } else {
+                results.shouldNotContain("made not entrant");
+            }
+        }
+
+        public void processC2(OutputAnalyzer results) {
+            results.shouldNotContain("made not entrant");
+        }
+    }
+
+    static class TestConstantMethodHandle extends TestConstantsInError {
+        public static void main(String[] args) {
+            // Non-existent holder class
+            run("MH1", NoClassDefFoundError.class,
+                mv -> mv.visitLdcInsn(new Handle(H_INVOKESTATIC, "UnknownClass", "ignored", "()V", false)));
+
+            // Inaccessible holder class
+            run("MH2", IllegalAccessError.class,
+                    mv -> mv.visitLdcInsn(new Handle(H_INVOKESTATIC, "java/lang/invoke/LambdaForm", "ignored", "()V", false)));
+
+            // Method vs InterfaceMethod mismatch
+            run("MH3", IncompatibleClassChangeError.class,
+                mv -> mv.visitLdcInsn(new Handle(H_INVOKESTATIC, "java/lang/Object", "ignored", "()V", true)));
+
+            // Non-existent method
+            run("MH4", NoSuchMethodError.class,
+                mv -> mv.visitLdcInsn(new Handle(H_INVOKESTATIC, "java/lang/Object", "cast", "()V", false)));
+        }
+
+        public void process(OutputAnalyzer results, boolean isC1) {
+            results.shouldMatch("Test_MH1/.*::test \\(3 bytes\\)$")
+                   .shouldMatch("Test_MH2/.*::test \\(3 bytes\\)$")
+                   .shouldMatch("Test_MH3/.*::test \\(3 bytes\\)$")
+                   .shouldMatch("Test_MH4/.*::test \\(3 bytes\\)$");
+
+            if (isC1 && Platform.isAArch64()) { // no code patching
+                results.shouldMatch("Test_MH1/.*::test \\(3 bytes\\)   made not entrant")
+                       .shouldMatch("Test_MH2/.*::test \\(3 bytes\\)   made not entrant")
+                       .shouldMatch("Test_MH3/.*::test \\(3 bytes\\)   made not entrant")
+                       .shouldMatch("Test_MH4/.*::test \\(3 bytes\\)   made not entrant");
+            } else {
+                results.shouldNotContain("made not entrant");
+            }
+        }
+    }
+
+    static class TestConstantMethodType extends TestConstantsInError {
+        public static void main(String[] args) {
+            run("MT1", NoClassDefFoundError.class,
+                mv -> mv.visitLdcInsn(Type.getMethodType("(LUnknownClass;)V")));
+            run("MT2", NoClassDefFoundError.class,
+                mv -> mv.visitLdcInsn(Type.getMethodType("()LUnknownClass;")));
+        }
+
+        public void process(OutputAnalyzer results, boolean isC1) {
+            results.shouldMatch("Test_MT1/.*::test \\(3 bytes\\)$")
+                   .shouldMatch("Test_MT2/.*::test \\(3 bytes\\)$");
+
+            if (isC1 && Platform.isAArch64()) { // no code patching
+                results.shouldMatch("Test_MT1/.*::test \\(3 bytes\\)   made not entrant")
+                       .shouldMatch("Test_MT2/.*::test \\(3 bytes\\)   made not entrant");
+            } else {
+                results.shouldNotContain("made not entrant");
+            }
+        }
+    }
+
+    static class TestConstantDynamic extends TestConstantsInError {
+        static int bsm1() throws Exception {
+            throw new AssertionError("should not be invoked");
+        }
+
+        static int bsm2(MethodHandles.Lookup lookup, String name, Class c) throws Exception {
+            throw new Exception("expected");
+        }
+
+        static final Handle BSM1 = new Handle(H_INVOKESTATIC, class2desc(TestConstantDynamic.class), "bsm1", "()I", false);
+        static final Handle BSM2 = new Handle(H_INVOKESTATIC, class2desc(TestConstantDynamic.class), "bsm2",
+                "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;)I",
+                false);
+
+        public static void main(String[] args) {
+            run("CD1", NoClassDefFoundError.class,
+                    mv -> {
+                        Handle bsm = new Handle(H_INVOKESTATIC, "UnknownClass", "unknown", "()LUnknownClass;", false);
+                        mv.visitLdcInsn(new ConstantDynamic("tmp", "LUnknownClass;", bsm));
+                    });
+            run("CD2", NoSuchMethodError.class,
+                    mv -> {
+                        Handle bsm = new Handle(H_INVOKESTATIC, class2desc(TestConstantDynamic.class), "unknown", "()I", false);
+                        mv.visitLdcInsn(new ConstantDynamic("tmp", "LUnknownClass;", bsm));
+                    });
+            run("CD3", BootstrapMethodError.class, mv -> mv.visitLdcInsn(new ConstantDynamic("tmp", "I", BSM1)));
+            run("CD4", BootstrapMethodError.class, mv -> mv.visitLdcInsn(new ConstantDynamic("tmp", "I", BSM2)));
+        }
+
+        public void process(OutputAnalyzer results, boolean isC1) {
+            if (isC1) {
+                results.shouldMatch("Test_CD1.*::test \\(3 bytes\\)   COMPILE SKIPPED: could not resolve a constant")
+                       .shouldMatch("Test_CD2.*::test \\(3 bytes\\)   COMPILE SKIPPED: could not resolve a constant")
+                       .shouldMatch("Test_CD3.*::test \\(3 bytes\\)   COMPILE SKIPPED: could not resolve a constant")
+                       .shouldMatch("Test_CD4.*::test \\(3 bytes\\)   COMPILE SKIPPED: could not resolve a constant");
+            } else {
+                results.shouldMatch("Test_CD1.*::test \\(3 bytes\\)$")
+                       .shouldMatch("Test_CD2.*::test \\(3 bytes\\)$")
+                       .shouldMatch("Test_CD3.*::test \\(3 bytes\\)$")
+                       .shouldMatch("Test_CD4.*::test \\(3 bytes\\)$");
+            }
+        }
+    }
+
+    static void run(TestConstantsInError test) throws Exception {
+        List<String> commonArgs = List.of(
+                "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
+                "-Xbatch", "-XX:CompileThreshold=100",
+                "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,*::test",
+                "-XX:+PrintCompilation",
+                "-XX:CompileCommand=print,*::test",
+                "-Dtest.classes=" + System.getProperty("test.classes", "."),
+                "-XX:+IgnoreUnrecognizedVMOptions",
+                test.getClass().getName());
+
+        ArrayList<String> c1Args = new ArrayList<>();
+        c1Args.addAll(List.of("-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-XX:+TracePatching"));
+        c1Args.addAll(commonArgs);
+
+        OutputAnalyzer outputC1 = ProcessTools.executeTestJvm(c1Args)
+                .shouldHaveExitValue(0);
+
+        test.process(outputC1, true);
+
+        ArrayList<String> c2Args = new ArrayList<>();
+        c2Args.add("-XX:-TieredCompilation");
+        c2Args.addAll(commonArgs);
+
+        OutputAnalyzer outputC2 = ProcessTools.executeTestJvm(c2Args)
+                .shouldHaveExitValue(0);
+
+        test.process(outputC2, false);
+    }
+
+    public static void main(String[] args) throws Exception {
+        run(new TestConstantClass());
+        run(new TestConstantMethodType());
+        run(new TestConstantMethodHandle());
+        run(new TestConstantDynamic());
+    }
+}

--- a/test/hotspot/jtreg/compiler/runtime/TestConstantsInError.java
+++ b/test/hotspot/jtreg/compiler/runtime/TestConstantsInError.java
@@ -72,7 +72,7 @@ public abstract class TestConstantsInError implements OutputProcessor {
     static byte[] generateClassFile(String suffix, Generator g) throws IOException {
         var cw = new ClassWriter(COMPUTE_MAXS | COMPUTE_FRAMES);
         String name = TEST_PREFIX + "_" + suffix;
-        cw.visit(V19, ACC_PUBLIC | ACC_SUPER, name, null, "java/lang/Object", null);
+        cw.visit(V18, ACC_PUBLIC | ACC_SUPER, name, null, "java/lang/Object", null);
 
         {
             var mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "test", "()V", null, null);


### PR DESCRIPTION
Backport of [JDK-8279822](https://bugs.openjdk.java.net/browse/JDK-8279822). Applied cleanly but I had to set the class file version of the test to `V18`. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279822](https://bugs.openjdk.java.net/browse/JDK-8279822): CI: Constant pool entries in error state are not supported


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - Committer)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/83.diff">https://git.openjdk.java.net/jdk18u/pull/83.diff</a>

</details>
