### PR TITLE
8281822: Test failures on non-DTrace builds due to incomplete DTrace* flags handling

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2049,6 +2049,14 @@ WB_ENTRY(jboolean, WB_IsJFRIncluded(JNIEnv* env))
 #endif // INCLUDE_JFR
 WB_END
 
+WB_ENTRY(jboolean, WB_IsDTraceIncluded(JNIEnv* env))
+#if defined(DTRACE_ENABLED)
+  return true;
+#else
+  return false;
+#endif // DTRACE_ENABLED
+WB_END
+
 #if INCLUDE_CDS
 
 WB_ENTRY(jint, WB_GetCDSOffsetForName(JNIEnv* env, jobject o, jstring name))
@@ -2694,6 +2702,7 @@ static JNINativeMethod methods[] = {
   {CC"areOpenArchiveHeapObjectsMapped",   CC"()Z",    (void*)&WB_AreOpenArchiveHeapObjectsMapped},
   {CC"isCDSIncluded",                     CC"()Z",    (void*)&WB_IsCDSIncluded },
   {CC"isJFRIncluded",                     CC"()Z",    (void*)&WB_IsJFRIncluded },
+  {CC"isDTraceIncluded",                  CC"()Z",    (void*)&WB_IsDTraceIncluded },
   {CC"isC2OrJVMCIIncluded",               CC"()Z",    (void*)&WB_isC2OrJVMCIIncluded },
   {CC"isJVMCISupportedByGC",              CC"()Z",    (void*)&WB_IsJVMCISupportedByGC},
   {CC"canWriteJavaHeapArchive",           CC"()Z",    (void*)&WB_CanWriteJavaHeapArchive },

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2917,6 +2917,18 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       jio_fprintf(defaultStream::error_stream(),
                   "ExtendedDTraceProbes flag is not applicable for this configuration\n");
       return JNI_EINVAL;
+    } else if (match_option(option, "-XX:+DTraceMethodProbes")) {
+      jio_fprintf(defaultStream::error_stream(),
+                  "DTraceMethodProbes flag is not applicable for this configuration\n");
+      return JNI_EINVAL;
+    } else if (match_option(option, "-XX:+DTraceAllocProbes")) {
+      jio_fprintf(defaultStream::error_stream(),
+                  "DTraceAllocProbes flag is not applicable for this configuration\n");
+      return JNI_EINVAL;
+    } else if (match_option(option, "-XX:+DTraceMonitorProbes")) {
+      jio_fprintf(defaultStream::error_stream(),
+                  "DTraceMonitorProbes flag is not applicable for this configuration\n");
+      return JNI_EINVAL;
 #endif // defined(DTRACE_ENABLED)
 #ifdef ASSERT
     } else if (match_option(option, "-XX:+FullGCALot")) {

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -63,6 +63,7 @@ requires.properties= \
     vm.debug \
     vm.hasSA \
     vm.hasJFR \
+    vm.hasDTrace \
     vm.rtm.cpu \
     vm.rtm.compiler \
     vm.cds \

--- a/test/hotspot/jtreg/compiler/runtime/Test8168712.java
+++ b/test/hotspot/jtreg/compiler/runtime/Test8168712.java
@@ -22,11 +22,29 @@
  */
 
 /**
- * @test
+ * @test id=with-dtrace
+ * @requires vm.debug
+ * @requires vm.hasDTrace
+ * @bug 8168712
+ *
+ * @run main/othervm -XX:CompileCommand=compileonly,Test8168712.*
+ *                   -XX:CompileCommand=compileonly,*Object.*
+ *                   -XX:+DTraceMethodProbes
+ *                   -XX:-UseOnStackReplacement
+ *                   -XX:+DeoptimizeRandom
+ *                   compiler.runtime.Test8168712
+ */
+
+/**
+ * @test id=without-dtrace
  * @requires vm.debug
  * @bug 8168712
  *
- * @run main/othervm -XX:CompileCommand=compileonly,Test8168712.* -XX:CompileCommand=compileonly,*Object.* -XX:+DTraceMethodProbes -XX:-UseOnStackReplacement -XX:+DeoptimizeRandom compiler.runtime.Test8168712
+ * @run main/othervm -XX:CompileCommand=compileonly,Test8168712.*
+ *                   -XX:CompileCommand=compileonly,*Object.*
+ *                   -XX:-UseOnStackReplacement
+ *                   -XX:+DeoptimizeRandom
+ *                   compiler.runtime.Test8168712
  */
 package compiler.runtime;
 

--- a/test/hotspot/jtreg/serviceability/7170638/SDTProbesGNULinuxTest.java
+++ b/test/hotspot/jtreg/serviceability/7170638/SDTProbesGNULinuxTest.java
@@ -28,6 +28,7 @@
  * @summary Test SDT probes available on GNU/Linux when DTRACE_ENABLED
  * @requires os.family == "linux"
  * @requires vm.flagless
+ * @requires vm.hasDTrace
  *
  * @library /test/lib
  * @run driver SDTProbesGNULinuxTest
@@ -36,7 +37,6 @@
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-import jtreg.SkippedException;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,17 +44,7 @@ import java.nio.file.Paths;
 
 public class SDTProbesGNULinuxTest {
     public static void main(String[] args) throws Throwable {
-        {
-            var pb = ProcessTools.createJavaProcessBuilder(
-                    "-XX:+ExtendedDTraceProbes",
-                    "-version");
-            var oa = new OutputAnalyzer(pb.start());
-            // This test only matters when build with DTRACE_ENABLED.
-            if (oa.getExitValue() != 0) {
-                throw new SkippedException("Not build using DTRACE_ENABLED");
-            }
-        }
-
+        // This test only matters when build with DTRACE_ENABLED.
         try (var libjvms = Files.walk(Paths.get(Utils.TEST_JDK))) {
             libjvms.filter(p -> "libjvm.so".equals(p.getFileName().toString()))
                    .map(Path::toAbsolutePath)

--- a/test/hotspot/jtreg/serviceability/dtrace/DTraceOptionsTest.java
+++ b/test/hotspot/jtreg/serviceability/dtrace/DTraceOptionsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc.  All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=enabled
+ * @bug 8281822
+ * @summary Test DTrace options are accepted on suitable builds
+ * @requires vm.flagless
+ * @requires vm.hasDTrace
+ *
+ * @library /test/lib
+ * @run driver DTraceOptionsTest true
+ */
+
+/*
+ * @test id=disabled
+ * @bug 8281822
+ * @summary Test DTrace options are rejected on unsuitable builds
+ * @requires vm.flagless
+ * @requires !vm.hasDTrace
+ *
+ * @library /test/lib
+ * @run driver DTraceOptionsTest disabled
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class DTraceOptionsTest {
+    public static void main(String[] args) throws Throwable {
+        boolean dtraceEnabled;
+        if (args.length > 0) {
+            dtraceEnabled = Boolean.parseBoolean(args[0]);
+        } else {
+            throw new IllegalArgumentException("Should provide the argument");
+        }
+
+        String[] options = {
+            "ExtendedDTraceProbes",
+            "DTraceMethodProbes",
+            "DTraceAllocProbes",
+            "DTraceMonitorProbes",
+        };
+
+        for (String opt : options) {
+            var pb = ProcessTools.createJavaProcessBuilder("-XX:+" + opt, "-version");
+            var oa = new OutputAnalyzer(pb.start());
+            if (dtraceEnabled) {
+                oa.shouldHaveExitValue(0);
+            } else {
+                oa.shouldNotHaveExitValue(0);
+                oa.shouldContain(opt + " flag is not applicable for this configuration");
+            }
+        }
+    }
+
+}

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -102,6 +102,7 @@ public class VMProps implements Callable<Map<String, String>> {
         // vm.hasJFR is "true" if JFR is included in the build of the VM and
         // so tests can be executed.
         map.put("vm.hasJFR", this::vmHasJFR);
+        map.put("vm.hasDTrace", this::vmHasDTrace);
         map.put("vm.jvmti", this::vmHasJVMTI);
         map.put("vm.cpu.features", this::cpuFeatures);
         map.put("vm.pageSize", this::vmPageSize);
@@ -366,6 +367,13 @@ public class VMProps implements Callable<Map<String, String>> {
      */
     protected String vmHasJVMTI() {
         return "" + WB.isJVMTIIncluded();
+    }
+
+    /**
+     * @return "true" if the VM is compiled with DTrace
+     */
+    protected String vmHasDTrace() {
+        return "" + WB.isDTraceIncluded();
     }
 
     /**

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -632,6 +632,7 @@ public class WhiteBox {
   public native boolean isSharedInternedString(String s);
   public native boolean isCDSIncluded();
   public native boolean isJFRIncluded();
+  public native boolean isDTraceIncluded();
   public native boolean canWriteJavaHeapArchive();
   public native Object  getResolvedReferences(Class<?> c);
   public native void    linkClass(Class<?> c);

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -633,6 +633,7 @@ public class WhiteBox {
   public native boolean isSharedInternedString(String s);
   public native boolean isCDSIncluded();
   public native boolean isJFRIncluded();
+  public native boolean isDTraceIncluded();
   public native boolean canWriteJavaHeapArchive();
   public native Object  getResolvedReferences(Class<?> c);
   public native void    linkClass(Class<?> c);


### PR DESCRIPTION
Backport of [JDK-8281822](https://bugs.openjdk.java.net/browse/JDK-8281822). Did not apply cleanly due to changes to `test/hotspot/jtreg/serviceability/7170638/SDTProbesGNULinuxTest.java`. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281822](https://bugs.openjdk.java.net/browse/JDK-8281822): Test failures on non-DTrace builds due to incomplete DTrace* flags handling


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/85.diff">https://git.openjdk.java.net/jdk18u/pull/85.diff</a>

</details>
