### PR TITLE
8282042: [testbug] FileEncodingTest.java depends on default encoding

### DIFF
--- a/test/jdk/java/lang/System/FileEncodingTest.java
+++ b/test/jdk/java/lang/System/FileEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8260265
+ * @bug 8260265 8282042
  * @summary Test file.encoding system property
  * @library /test/lib
  * @build jdk.test.lib.process.*
@@ -40,7 +40,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class FileEncodingTest {
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+    private static final String OS_NAME = System.getProperty("os.name");
 
     @DataProvider
     public Object[][] fileEncodingToDefault() {
@@ -56,7 +56,7 @@ public class FileEncodingTest {
     @Test(dataProvider = "fileEncodingToDefault")
     public void testFileEncodingToDefault(String fileEncoding, String expected) throws Exception {
         if (fileEncoding.equals("COMPAT")) {
-            if (IS_WINDOWS) {
+            if (OS_NAME.startsWith("Windows")) {
                 // Only tests on English locales
                 if (Locale.getDefault().getLanguage().equals("en")) {
                     expected = "windows-1252";
@@ -64,6 +64,8 @@ public class FileEncodingTest {
                     System.out.println("Tests only run on Windows with English locales");
                     return;
                 }
+            } else if (OS_NAME.startsWith("AIX")) {
+                expected = "ISO-8859-1";
             } else {
                 expected = "US-ASCII";
             }


### PR DESCRIPTION
Backporting this small testbug fix to jdk18u as requested [here](https://github.com/eclipse-openj9/openj9/issues/14472#issuecomment-1048328921)

This issue fixes a testbug present on AIX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282042](https://bugs.openjdk.java.net/browse/JDK-8282042): [testbug] FileEncodingTest.java depends on default encoding


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/96.diff">https://git.openjdk.java.net/jdk18u/pull/96.diff</a>

</details>
