### PR TITLE
Backport d6fa8b004bcd0a2fc1015055d0177428889b4c31

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -166,9 +166,9 @@ template <int N> static void get_header_version(char (&header_version) [N]) {
   assert(header_version[JVM_IDENT_MAX-1] == 0, "must be");
 }
 
-FileMapInfo::FileMapInfo(bool is_static) {
-  memset((void*)this, 0, sizeof(FileMapInfo));
-  _is_static = is_static;
+FileMapInfo::FileMapInfo(bool is_static) :
+  _is_static(is_static), _file_open(false), _is_mapped(false), _fd(-1), _file_offset(0),
+  _full_path(nullptr), _base_archive_name(nullptr), _header(nullptr) {
   if (_is_static) {
     assert(_current_info == NULL, "must be singleton"); // not thread safe
     _current_info = this;
@@ -176,8 +176,6 @@ FileMapInfo::FileMapInfo(bool is_static) {
     assert(_dynamic_archive_info == NULL, "must be singleton"); // not thread safe
     _dynamic_archive_info = this;
   }
-  _file_offset = 0;
-  _file_open = false;
 }
 
 FileMapInfo::~FileMapInfo() {
@@ -187,6 +185,14 @@ FileMapInfo::~FileMapInfo() {
   } else {
     assert(_dynamic_archive_info == this, "must be singleton"); // not thread safe
     _dynamic_archive_info = NULL;
+  }
+
+  if (_header != nullptr) {
+    os::free(_header);
+  }
+
+  if (_file_open) {
+    ::close(_fd);
   }
 }
 


### PR DESCRIPTION
I would like to backport this patch to 18u, to fix a memory leak, also eliminates dangerous `memset` call, could potentially result in fatal crash.

The original patch does not apply cleanly, due to JDK-8261455, where it changed `FileMapInfo`'s constructor signature to pass in `full_path` as a parameter. The conflict is resolved manually by initializing `_full_path` to `nullptr`

Test:

- [x] hotspot_cds 