### PR TITLE
8284548: Invalid XPath expression causes StringIndexOutOfBoundsException

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/Lexer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/Lexer.java
@@ -24,7 +24,6 @@ import com.sun.org.apache.xalan.internal.res.XSLMessages;
 import com.sun.org.apache.xml.internal.utils.PrefixResolver;
 import com.sun.org.apache.xpath.internal.res.XPATHErrorResources;
 import java.util.List;
-import java.util.Objects;
 import javax.xml.transform.TransformerException;
 import jdk.xml.internal.XMLSecurityManager;
 import jdk.xml.internal.XMLSecurityManager.Limit;
@@ -33,7 +32,7 @@ import jdk.xml.internal.XMLSecurityManager.Limit;
  * This class is in charge of lexical processing of the XPath
  * expression into tokens.
  *
- * @LastModified: Jan 2022
+ * @LastModified: Apr 2022
  */
 class Lexer
 {
@@ -451,8 +450,7 @@ class Lexer
    * @return the next char
    */
   private char peekNext(String s, int index) {
-      Objects.checkIndex(index, s.length());
-      if (s.length() > index) {
+      if (index >= 0 && index < s.length() - 1) {
           return s.charAt(index + 1);
       }
       return 0;

--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExceptionTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExceptionTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package xpath;
+
+import java.io.StringReader;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+/*
+ * @test
+ * @bug 8284548
+ * @run testng xpath.XPathExceptionTest
+ * @summary This is a general test for Exception handling. Additional cases may
+ * be added with a bug id in the test cases.
+ */
+public class XPathExceptionTest {
+
+    /*
+     * DataProvider: invalid XPath expressions
+     * Illegal expressions and structures that may escape the validation check.
+     */
+    @DataProvider(name = "invalid")
+    public Object[][] getInvalid() throws Exception {
+        return new Object[][]{
+            // @bug JDK-8284548: expressions ending with relational operators
+            // throw StringIndexOutOfBoundsException instead of XPathExpressionException
+            {"/a/b/c[@d >"},
+            {"/a/b/c[@d <"},
+            {"/a/b/c[@d >="},
+            {">>"},
+        };
+    }
+
+    /**
+     * Verifies that the XPath processor throws XPathExpressionException upon
+     * encountering illegal XPath expressions.
+     * @param invalidExp an illegal XPath expression
+     * @throws Exception if the test fails
+     */
+    @Test(dataProvider = "invalid")
+    public void testIllegalExp(String invalidExp) throws Exception {
+        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document doc = builder.parse(new org.xml.sax.InputSource(new StringReader("<A/>")));
+        Assert.assertThrows(XPathExpressionException.class, () -> evaluate(doc, invalidExp));
+    }
+
+    private void evaluate(Document doc, String s) throws XPathExpressionException {
+        XPath xp = XPathFactory.newInstance().newXPath();
+        XPathExpression xe = xp.compile(s);
+        xe.evaluateExpression(doc, Node.class);
+    }
+}


### PR DESCRIPTION
Clean backport of https://github.com/openjdk/jdk/commit/994f2e9271355bebf355279d0208c1d2054bab27 to jdk18u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284548](https://bugs.openjdk.java.net/browse/JDK-8284548): Invalid XPath expression causes StringIndexOutOfBoundsException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/102.diff">https://git.openjdk.java.net/jdk18u/pull/102.diff</a>

</details>
