### PR TITLE
8283725: Launching java with "-Xlog:gc*=trace,safepoint*=trace,class*=trace" crashes the JVM

### DIFF
--- a/src/hotspot/share/logging/logOutput.cpp
+++ b/src/hotspot/share/logging/logOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,6 +334,11 @@ void LogOutput::update_config_string(const size_t on_level[LogLevel::Count]) {
 
     assert(n_deviates < deviating_tagsets, "deviating tag set array overflow");
     assert(prev_deviates > n_deviates, "number of deviating tag sets must never grow");
+
+    if (n_deviates == 1 && n_selections == 0) {
+      // we're done as we couldn't reduce things any further
+      break;
+    }
   }
   FREE_C_HEAP_ARRAY(LogTagSet*, deviates);
   FREE_C_HEAP_ARRAY(Selection, selections);


### PR DESCRIPTION
Backport of JDK-8283725 to JDK-18u.  Patch applied cleanly and was tested with Mach5 tiers 1-2.

Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283725](https://bugs.openjdk.java.net/browse/JDK-8283725): Launching java with "-Xlog:gc*=trace,safepoint*=trace,class*=trace" crashes the JVM


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/112.diff">https://git.openjdk.java.net/jdk18u/pull/112.diff</a>

</details>
