### PR TITLE
8286029: Add classpath exemption to globals_vectorApiSupport_***.S.inc

### DIFF
--- a/src/jdk.incubator.vector/linux/native/libjsvml/globals_vectorApiSupport_linux.S.inc
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/globals_vectorApiSupport_linux.S.inc
@@ -1,10 +1,12 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/windows/native/libjsvml/globals_vectorApiSupport_windows.S.inc
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/globals_vectorApiSupport_windows.S.inc
@@ -1,9 +1,11 @@
-; Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+; Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
Backports classpath exemption in `globals_vectorApiSupport_***.S.inc`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286029](https://bugs.openjdk.java.net/browse/JDK-8286029): Add classpath exemption to globals_vectorApiSupport_***.S.inc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/122/head:pull/122` \
`$ git checkout pull/122`

Update a local copy of the PR: \
`$ git checkout pull/122` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 122`

View PR using the GUI difftool: \
`$ git pr show -t 122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/122.diff">https://git.openjdk.java.net/jdk18u/pull/122.diff</a>

</details>
