### PR TITLE
8286283: assert(func2 == 0 && func3 == 0) failed: not unary

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2359,7 +2359,6 @@ bool Compile::has_vbox_nodes() {
 
 static bool is_vector_unary_bitwise_op(Node* n) {
   return n->Opcode() == Op_XorV &&
-         n->req() == 2 &&
          VectorNode::is_vector_bitwise_not_pattern(n);
 }
 
@@ -2367,7 +2366,7 @@ static bool is_vector_binary_bitwise_op(Node* n) {
   switch (n->Opcode()) {
     case Op_AndV:
     case Op_OrV:
-      return n->req() == 2;
+      return true;
 
     case Op_XorV:
       return !is_vector_unary_bitwise_op(n);
@@ -2382,6 +2381,9 @@ static bool is_vector_ternary_bitwise_op(Node* n) {
 }
 
 static bool is_vector_bitwise_op(Node* n) {
+  if (n->is_predicated_vector()) {
+    return false;
+  }
   return is_vector_unary_bitwise_op(n)  ||
          is_vector_binary_bitwise_op(n) ||
          is_vector_ternary_bitwise_op(n);

--- a/test/hotspot/jtreg/compiler/vectorapi/Test8286283.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/Test8286283.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.*;
+import jdk.test.lib.format.ArrayDiff;
+
+/*
+ * @test
+ * @bug 8286283
+ * @summary Test correctness of macrologic optimization
+ * @modules jdk.incubator.vector
+ * @requires vm.cpu.features ~= ".*avx512f.*"
+ * @library /test/lib
+ *
+ * @run main compiler.vectorapi.Test8286283
+ */
+public class Test8286283 {
+   public static final int LEN = 1024;
+   public static VectorSpecies<Integer> SPECIES = IntVector.SPECIES_512;
+
+    public static void test_vec(int [] r, int [] a, int [] b, int [] c) {
+        VectorMask<Integer> mask = VectorMask.fromLong(SPECIES, -1);
+        for(int i = 0 ; i < r.length; i+=SPECIES.length()) {
+            IntVector avec = IntVector.fromArray(SPECIES, a, i);
+            IntVector bvec = IntVector.fromArray(SPECIES, b, i);
+            IntVector cvec = IntVector.fromArray(SPECIES, c, i);
+            avec.lanewise(VectorOperators.AND, bvec)
+                .lanewise(VectorOperators.OR, cvec)
+                .lanewise(VectorOperators.NOT)
+                .lanewise(VectorOperators.NOT, mask)
+                .reinterpretAsInts()
+                .intoArray(r, i);
+        }
+    }
+
+    public static void test_scalar(int [] r, int [] a, int [] b, int [] c) {
+        for(int i = 0; i < r.length; i++) {
+            r[i] = ~(~(a[i] & b[i] | c[i]));
+        }
+    }
+
+    public static void main(String [] args) {
+        int res = 0;
+        int [] a = new int[LEN];
+        int [] b = new int[LEN];
+        int [] c = new int[LEN];
+        int [] rv = new int[LEN];
+        int [] rs = new int[LEN];
+
+        for(int i = 0 ; i < LEN; i++) {
+            a[i] = i;
+            b[i] = i+1;
+            c[i] = i+2;
+        }
+
+        for (int i = 0 ; i < 10000; i++) {
+            test_vec(rv, a, b ,c);
+            test_scalar(rs, a, b ,c);
+        }
+
+        var diff = ArrayDiff.of(rv, rs);
+        if (!diff.areEqual()) {
+            throw new AssertionError("scalar vs vector result mismatch: " + diff.format());
+        }
+    }
+}


### PR DESCRIPTION
Issue relates to incorrect conditional check based on input edge count to skip predicated unary/binary logic operation during logic cone collection stage of macro logic optimization. 

Problem is only seen with JDK-18 released version and not with JDK mainline which contains a re-designed algorithm for macrologic optimization to support predicated logic operations.

Patch replaces edge count based check to detect predicated IR node with a strict node level flag based check.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286283](https://bugs.openjdk.java.net/browse/JDK-8286283): assert(func2 == 0 && func3 == 0) failed: not unary


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/123.diff">https://git.openjdk.java.net/jdk18u/pull/123.diff</a>

</details>
