### PR TITLE
8285921: serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java fails on Alpine

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@ import jdk.test.lib.process.OutputAnalyzer;
 /*
  * @test
  * @bug 8165736 8252657
+ * @comment muslc dlclose is a no-op, see 8285921
+ * @requires !vm.musl
  * @library /test/lib
  * @run testng AttachReturnError
  */


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285921](https://bugs.openjdk.java.net/browse/JDK-8285921): serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java fails on Alpine


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/125.diff">https://git.openjdk.java.net/jdk18u/pull/125.diff</a>

</details>
