### PR TITLE
8285828: runtime/execstack/TestCheckJDK.java fails with zipped debug symbols

### DIFF
--- a/test/hotspot/jtreg/runtime/execstack/TestCheckJDK.java
+++ b/test/hotspot/jtreg/runtime/execstack/TestCheckJDK.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class TestCheckJDK {
     static void checkExecStack(Path file) {
         String filename = file.toString();
         Path parent = file.getParent();
-        if (parent.endsWith("bin") || filename.endsWith(".so")) {
+        if ((parent.endsWith("bin") && !filename.endsWith(".diz")) || filename.endsWith(".so")) {
             if (!WB.checkLibSpecifiesNoexecstack(filename)) {
                 System.out.println("Library does not have the noexecstack bit set: " + filename);
                 testPassed = false;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285828](https://bugs.openjdk.java.net/browse/JDK-8285828): runtime/execstack/TestCheckJDK.java fails with zipped debug symbols


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/127/head:pull/127` \
`$ git checkout pull/127`

Update a local copy of the PR: \
`$ git checkout pull/127` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 127`

View PR using the GUI difftool: \
`$ git pr show -t 127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/127.diff">https://git.openjdk.java.net/jdk18u/pull/127.diff</a>

</details>
