### PR TITLE
8282080: Lambda deserialization fails for Object method references on interfaces

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -755,6 +755,14 @@ public class LambdaToMethod extends TreeTranslator {
         String functionalInterfaceClass = classSig(targetType);
         String functionalInterfaceMethodName = samSym.getSimpleName().toString();
         String functionalInterfaceMethodSignature = typeSig(types.erasure(samSym.type));
+        Symbol baseMethod = refSym.baseSymbol();
+        Symbol origMethod = baseMethod.baseSymbol();
+        if (baseMethod != origMethod && origMethod.owner == syms.objectType.tsym) {
+            //the implementation method is a java.lang.Object method transferred to an
+            //interface that does not declare it. Runtime will refer to this method as to
+            //a java.lang.Object method, so do the same:
+            refSym = ((MethodSymbol) origMethod).asHandle();
+        }
         String implClass = classSig(types.erasure(refSym.owner.type));
         String implMethodName = refSym.getQualifiedName().toString();
         String implMethodSignature = typeSig(types.erasure(refSym.type));

--- a/test/langtools/tools/javac/lambda/SerializableObjectMethods.java
+++ b/test/langtools/tools/javac/lambda/SerializableObjectMethods.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8282080
+ * @summary Check that serializable lambdas referring to j.l.Object methods work.
+ * @compile SerializableObjectMethods.java
+ * @run main SerializableObjectMethods
+ */
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+public class SerializableObjectMethods {
+
+    interface I1 extends Serializable {}
+
+    interface I2 extends I1 {
+
+        @Override
+        public int hashCode();
+
+    }
+
+    interface F<T, R> extends Serializable {
+
+        R apply(T t);
+    }
+
+    public static void main(String[] args) throws Exception {
+        new SerializableObjectMethods().run();
+    }
+
+    void run() throws IOException, ClassNotFoundException {
+        saveLoad((F<I1, Integer>) I1::hashCode).apply(new I1() {});
+        saveLoad((F<I2, Integer>) I2::hashCode).apply(new I2() {});
+    }
+
+    <T, R> F<T, R> saveLoad(F<T, R> value) throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try ( ObjectOutputStream oos = new ObjectOutputStream(out)) {
+            oos.writeObject(value);
+        }
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+            return (F<T, R>) ois.readObject();
+        }
+    }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8282080](https://bugs.openjdk.java.net/browse/JDK-8282080): Lambda deserialization fails for Object method references on interfaces
 * [JDK-8286047](https://bugs.openjdk.java.net/browse/JDK-8286047): Lambda deserialization fails for Object method references on interfaces (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/133.diff">https://git.openjdk.java.net/jdk18u/pull/133.diff</a>

</details>
