### PR TITLE
8287119: Add Distrust.java to ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -676,6 +676,8 @@ sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
 sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java 8277970 linux-all,macosx-x64
 
+sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java    8287109 generic-all
+
 ############################################################################
 
 # jdk_sound


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8287119](https://bugs.openjdk.java.net/browse/JDK-8287119), commit [da8fd454](https://github.com/openjdk/jdk/commit/da8fd4547f27cea8d940df5c99dd99503617bf4e) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Rajan Halade on 21 May 2022 and was reviewed by Bradford Wetmore.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287119](https://bugs.openjdk.java.net/browse/JDK-8287119): Add Distrust.java to ProblemList


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/136/head:pull/136` \
`$ git checkout pull/136`

Update a local copy of the PR: \
`$ git checkout pull/136` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 136`

View PR using the GUI difftool: \
`$ git pr show -t 136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/136.diff">https://git.openjdk.java.net/jdk18u/pull/136.diff</a>

</details>
