### PR TITLE
8287644: [18u] Backport of JDK-8240903 causes test errors

### DIFF
--- a/test/jdk/tools/jmod/hashes/HashesOrderTest.java
+++ b/test/jdk/tools/jmod/hashes/HashesOrderTest.java
@@ -51,7 +51,6 @@ public class HashesOrderTest {
             new RuntimeException("jmod tool not found")
         );
 
-    private String DATE = "2021-01-06T14:36:00+02:00";
     private int NUM_MODULES = 64;
     private Path mods;
     private Path lib1;
@@ -113,7 +112,6 @@ public class HashesOrderTest {
         List<String> args = new ArrayList<>();
         args.add("create");
         Collections.addAll(args, options);
-        Collections.addAll(args, "--date", DATE);
         Collections.addAll(args, "--class-path", mclasses.toString(),
                            outfile.toString());
 


### PR DESCRIPTION
jmod in 18u does not have the option --date which causes a test error. We can leave out its usage in the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287644](https://bugs.openjdk.java.net/browse/JDK-8287644): [18u] Backport of JDK-8240903 causes test errors


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/145/head:pull/145` \
`$ git checkout pull/145`

Update a local copy of the PR: \
`$ git checkout pull/145` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 145`

View PR using the GUI difftool: \
`$ git pr show -t 145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/145.diff">https://git.openjdk.java.net/jdk18u/pull/145.diff</a>

</details>
