### PR TITLE
8286855: javac error on invalid jar should only print filename

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -564,7 +564,7 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
                 try {
                     this.fileSystem = jarFSProvider.newFileSystem(archivePath, env);
                 } catch (ZipException ze) {
-                    throw new IOException("ZipException opening \"" + archivePath + "\": " + ze.getMessage(), ze);
+                    throw new IOException("ZipException opening \"" + archivePath.getFileName() + "\": " + ze.getMessage(), ze);
                 }
             } else {
                 this.fileSystem = FileSystems.newFileSystem(archivePath, (ClassLoader)null);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8286855](https://bugs.openjdk.java.net/browse/JDK-8286855), commit [1606d554](https://github.com/openjdk/jdk/commit/1606d5545b8daad840575b7cfd97b94fd8a3d41d) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Christoph Langer on 30 May 2022 and was reviewed by Jaikiran Pai and Martin Doerr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286855](https://bugs.openjdk.java.net/browse/JDK-8286855): javac error on invalid jar should only print filename


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/146.diff">https://git.openjdk.java.net/jdk18u/pull/146.diff</a>

</details>
