### PR TITLE
8285515: (dc) DatagramChannel.disconnect fails with "Invalid argument" on macOS 12.4

### DIFF
--- a/src/java.base/unix/native/libnio/ch/DatagramChannelImpl.c
+++ b/src/java.base/unix/native/libnio/ch/DatagramChannelImpl.c
@@ -50,20 +50,28 @@ Java_sun_nio_ch_DatagramChannelImpl_disconnect0(JNIEnv *env, jclass clazz,
     jint fd = fdval(env, fdo);
     int rv;
 
+#if defined(__APPLE__)
+    // On macOS systems we use disconnectx
+    rv = disconnectx(fd, SAE_ASSOCID_ANY, SAE_CONNID_ANY);
+#else
     SOCKETADDRESS sa;
+    memset(&sa, 0, sizeof(sa));
+    #if defined(_ALLBSD_SOURCE)
+        sa.sa.sa_family = isIPv6 ? AF_INET6 : AF_INET;
+    #else
+        sa.sa.sa_family = AF_UNSPEC;
+    #endif
     socklen_t len = isIPv6 ? sizeof(struct sockaddr_in6) :
                              sizeof(struct sockaddr_in);
-
-    memset(&sa, 0, sizeof(sa));
-#if defined(_ALLBSD_SOURCE)
-    sa.sa.sa_family = isIPv6 ? AF_INET6 : AF_INET;
-#else
-    sa.sa.sa_family = AF_UNSPEC;
+    rv = connect(fd, &sa.sa, len);
 #endif
 
-    rv = connect(fd, &sa.sa, len);
-
-#if defined(_ALLBSD_SOURCE)
+#if defined(_ALLBSD_SOURCE) && !defined(__APPLE__)
+    // On _ALLBSD_SOURCE except __APPLE__ we consider EADDRNOTAVAIL
+    // error to be OK and ignore it. __APPLE__ systems are excluded
+    // in this check since for __APPLE__ systems, unlike other BSD systems,
+    // we issue a "disconnectx" call (a few lines above),
+    // which isn't expected to return this error code.
     if (rv < 0 && errno == EADDRNOTAVAIL)
         rv = errno = 0;
 #elif defined(_AIX)

--- a/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 7132924
+ * @bug 7132924 8285515
  * @library /test/lib
  * @key intermittent
  * @summary Test DatagramChannel.disconnect when DatagramChannel is connected to an IPv4 socket


### PR DESCRIPTION
mach tests for tier1 and tier2 all pass on MacOs https://mach5.us.oracle.com/mdash/jobs/lpinto-jdk18u-20220603-1032-33065098

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285515](https://bugs.openjdk.java.net/browse/JDK-8285515): (dc) DatagramChannel.disconnect fails with "Invalid argument" on macOS 12.4


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18u pull/147/head:pull/147` \
`$ git checkout pull/147`

Update a local copy of the PR: \
`$ git checkout pull/147` \
`$ git pull https://git.openjdk.java.net/jdk18u pull/147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 147`

View PR using the GUI difftool: \
`$ git pr show -t 147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18u/pull/147.diff">https://git.openjdk.java.net/jdk18u/pull/147.diff</a>

</details>
