### PR TITLE
8287894: Use fixed timestamp as an alternative of __DATE__ macro in jdk.jdi to make Windows build reproducible

### DIFF
--- a/make/modules/jdk.jdi/Lib.gmk
+++ b/make/modules/jdk.jdi/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -29,10 +29,16 @@ include LibCommon.gmk
 
 ifeq ($(call isTargetOs, windows), true)
 
+  CFLAGS_LIBDT_SHMEM := $(CFLAGS_JDKLIB)
+
+  ifneq ($(HOTSPOT_BUILD_TIME), )
+    CFLAGS_LIBDT_SHMEM += -DSHMEM_BUILD_TIME='"$(HOTSPOT_BUILD_TIME)"'
+  endif
+
   $(eval $(call SetupJdkLibrary, BUILD_LIBDT_SHMEM, \
       NAME := dt_shmem, \
       OPTIMIZATION := LOW, \
-      CFLAGS := $(CFLAGS_JDKLIB), \
+      CFLAGS := $(CFLAGS_LIBDT_SHMEM), \
       EXTRA_HEADER_DIRS := \
           jdk.jdwp.agent:include \
           jdk.jdwp.agent:libjdwp/export, \

--- a/src/jdk.jdi/share/native/libdt_shmem/shmemBase.h
+++ b/src/jdk.jdi/share/native/libdt_shmem/shmemBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,11 +49,15 @@ jint shmemBase_receivePacket(SharedMemoryConnection *, jdwpPacket *packet);
 jint shmemBase_name(SharedMemoryTransport *, char **name);
 jint shmemBase_getlasterror(char *msg, jint size);
 
+#ifndef SHMEM_BUILD_TIME
+#define SHMEM_BUILD_TIME __DATE__
+#endif
+
 #ifdef DEBUG
 #define SHMEM_ASSERT(expression)  \
 do {                            \
     if (!(expression)) {                \
-        exitTransportWithError("assertion failed", __FILE__, __DATE__, __LINE__); \
+        exitTransportWithError("assertion failed", __FILE__, SHMEM_BUILD_TIME, __LINE__); \
     } \
 } while (0)
 #else
@@ -63,7 +67,7 @@ do {                            \
 #define SHMEM_GUARANTEE(expression) \
 do {                            \
     if (!(expression)) {                \
-        exitTransportWithError("assertion failed", __FILE__, __DATE__, __LINE__); \
+        exitTransportWithError("assertion failed", __FILE__, SHMEM_BUILD_TIME, __LINE__); \
     } \
 } while (0)
 

--- a/src/jdk.jdi/windows/native/libdt_shmem/shmem_md.c
+++ b/src/jdk.jdi/windows/native/libdt_shmem/shmem_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,12 +39,16 @@
 
 static HANDLE memHandle = NULL;
 
+#ifndef SHMEM_BUILD_TIME
+#define SHMEM_BUILD_TIME __DATE__
+#endif
+
 #ifdef DEBUG
 #define sysAssert(expression) {         \
     if (!(expression)) {                \
             exitTransportWithError \
             ("\"%s\", line %d: assertion failure\n", \
-             __FILE__, __DATE__, __LINE__); \
+             __FILE__, SHMEM_BUILD_TIME, __LINE__); \
     }                                   \
 }
 #else


### PR DESCRIPTION
Hi!

Here is a backport of 8287894 that fixes reproducible debug build for Windows. The original patch applied cleanly.

Verification (Windows10/MSVS2019): `bash ./configure --with-boot-jdk=c:/work/boot-jdk/jdk-18 --with-debug-level=fastdebug --with-hotspot-build-time="6/7/2022 2:35pm" --with-extra-cflags="/experimental:deterministic"`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287894](https://bugs.openjdk.org/browse/JDK-8287894): Use fixed timestamp as an alternative of __DATE__ macro in jdk.jdi to make Windows build reproducible


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk18u pull/151/head:pull/151` \
`$ git checkout pull/151`

Update a local copy of the PR: \
`$ git checkout pull/151` \
`$ git pull https://git.openjdk.org/jdk18u pull/151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 151`

View PR using the GUI difftool: \
`$ git pr show -t 151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk18u/pull/151.diff">https://git.openjdk.org/jdk18u/pull/151.diff</a>

</details>
