### PR TITLE
8270090: C2: LCM may prioritize CheckCastPP nodes over projections

### DIFF
--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -488,9 +488,10 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
 
 
 //------------------------------select-----------------------------------------
-// Select a nice fellow from the worklist to schedule next. If there is only
-// one choice, then use it. Projections take top priority for correctness
-// reasons - if I see a projection, then it is next.  There are a number of
+// Select a nice fellow from the worklist to schedule next. If there is only one
+// choice, then use it. CreateEx nodes must start their blocks and are selected
+// eagerly. After them, projections take top priority for correctness. Next
+// after projections are constants and CheckCastPP nodes. There are a number of
 // other special cases, for instructions that consume condition codes, et al.
 // These are chosen immediately. Some instructions are required to immediately
 // precede the last instruction in the block, and these are taken last. Of the
@@ -528,13 +529,32 @@ Node* PhaseCFG::select(
     Node *n = worklist[i];      // Get Node on worklist
 
     int iop = n->is_Mach() ? n->as_Mach()->ideal_Opcode() : 0;
-    if( n->is_Proj() ||         // Projections always win
-        n->Opcode()== Op_Con || // So does constant 'Top'
-        iop == Op_CreateEx ||   // Create-exception must start block
-        iop == Op_CheckCastPP
-        ) {
+    if (iop == Op_CreateEx) {
+      // CreateEx must start the block (after Phi and Parm nodes which are
+      // pre-scheduled): select it right away.
       worklist.map(i,worklist.pop());
       return n;
+    }
+
+    uint n_choice = 2;
+    if (n->is_Proj()) {
+      // Projections should follow their parents.
+      n_choice = 5;
+    } else if (n->Opcode() == Op_Con || iop == Op_CheckCastPP) {
+      // Constants and CheckCastPP nodes have higher priority than the rest of
+      // the nodes tested below.
+      n_choice = 4;
+    }
+
+    if (n_choice >= 4 && choice < n_choice) {
+      // n is a constant, a projection, or a CheckCastPP node: record as current
+      // winner, but keep looking for higher-priority nodes in the worklist.
+      choice  = n_choice;
+      // Latency and score are only used to break ties among low-priority nodes.
+      latency = 0;
+      score   = 0;
+      idx     = i;
+      continue;
     }
 
     // Final call in a block must be adjacent to 'catch'
@@ -554,8 +574,6 @@ Node* PhaseCFG::select(
         continue;
       }
     }
-
-    uint n_choice  = 2;
 
     // See if this instruction is consumed by a branch. If so, then (as the
     // branch is the last instruction in the basic block) force it to the
@@ -1060,10 +1078,6 @@ bool PhaseCFG::schedule_local(Block* block, GrowableArray<int>& ready_cnt, Vecto
         // of the phi to be scheduled first. The select() method breaks
         // ties in scheduling by worklist order.
         delay.push(m);
-      } else if (m->is_Mach() && m->as_Mach()->ideal_Opcode() == Op_CreateEx) {
-        // Force the CreateEx to the top of the list so it's processed
-        // first and ends up at the start of the block.
-        worklist.insert(0, m);
       } else {
         worklist.push(m);         // Then on to worklist!
       }


### PR DESCRIPTION
Backport of [JDK-8270090](https://bugs.openjdk.java.net/browse/JDK-8270090). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270090](https://bugs.openjdk.org/browse/JDK-8270090): C2: LCM may prioritize CheckCastPP nodes over projections


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk18u pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/jdk18u pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk18u/pull/153.diff">https://git.openjdk.org/jdk18u/pull/153.diff</a>

</details>
