### PR TITLE
8280696: C2 compilation hits assert(is_dominator(c, n_ctrl)) failed

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2131,7 +2131,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           doit = false;
           break;
         }
-        if (in(i)->in(AddPNode::Offset) != base) {
+        if (in(i)->in(AddPNode::Base) != base) {
           base = NULL;
         }
         if (in(i)->in(AddPNode::Offset) != offset) {

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -334,9 +334,11 @@ Node *PhaseIdealLoop::has_local_phi_input( Node *n ) {
       // We allow the special case of AddP's with no local inputs.
       // This allows us to split-up address expressions.
       if (m->is_AddP() &&
-          get_ctrl(m->in(2)) != n_ctrl &&
-          get_ctrl(m->in(3)) != n_ctrl) {
-        // Move the AddP up to dominating point
+          get_ctrl(m->in(AddPNode::Base)) != n_ctrl &&
+          get_ctrl(m->in(AddPNode::Address)) != n_ctrl &&
+          get_ctrl(m->in(AddPNode::Offset)) != n_ctrl) {
+        // Move the AddP up to the dominating point. That's fine because control of m's inputs
+        // must dominate get_ctrl(m) == n_ctrl and we just checked that the input controls are != n_ctrl.
         Node* c = find_non_split_ctrl(idom(n_ctrl));
         if (c->is_OuterStripMinedLoop()) {
           c->as_Loop()->verify_strip_mined(1);
@@ -1603,6 +1605,8 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
   }
 }
 
+// Compute the early control of a node by following its inputs until we reach
+// nodes that are pinned. Then compute the LCA of the control of all pinned nodes.
 Node* PhaseIdealLoop::compute_early_ctrl(Node* n, Node* n_ctrl) {
   Node* early_ctrl = NULL;
   ResourceMark rm;
@@ -1618,17 +1622,14 @@ Node* PhaseIdealLoop::compute_early_ctrl(Node* n, Node* n_ctrl) {
     } else {
       for (uint j = 0; j < m->req(); j++) {
         Node* in = m->in(j);
-        if (in == NULL) {
-          continue;
+        if (in != NULL) {
+          wq.push(in);
         }
-        wq.push(in);
       }
     }
     if (c != NULL) {
-      assert(is_dominator(c, n_ctrl), "");
-      if (early_ctrl == NULL) {
-        early_ctrl = c;
-      } else if (is_dominator(early_ctrl, c)) {
+      assert(is_dominator(c, n_ctrl), "control input must dominate current control");
+      if (early_ctrl == NULL || is_dominator(early_ctrl, c)) {
         early_ctrl = c;
       }
     }


### PR DESCRIPTION
Backport of [JDK-8280696](https://bugs.openjdk.java.net/browse/JDK-8280696). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280696](https://bugs.openjdk.org/browse/JDK-8280696): C2 compilation hits assert(is_dominator(c, n_ctrl)) failed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk18u pull/161/head:pull/161` \
`$ git checkout pull/161`

Update a local copy of the PR: \
`$ git checkout pull/161` \
`$ git pull https://git.openjdk.org/jdk18u pull/161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 161`

View PR using the GUI difftool: \
`$ git pr show -t 161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk18u/pull/161.diff">https://git.openjdk.org/jdk18u/pull/161.diff</a>

</details>
