### PR TITLE
8286847: Rotate vectors don't support byte or short

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -332,7 +332,6 @@ bool VectorNode::is_vector_rotate_supported(int vopc, uint vlen, BasicType bt) {
              Matcher::match_rule_supported_vector(Op_LShiftVL,  vlen, bt) &&
              Matcher::match_rule_supported_vector(Op_URShiftVL, vlen, bt);
     default:
-      assert(false, "not supported: %s", type2name(bt));
       return false;
   }
 }

--- a/test/hotspot/jtreg/compiler/vectorization/TestRotateByteAndShortVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestRotateByteAndShortVector.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2022, Loongson Technology Co. Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8286847
+ * @key randomness
+ * @summary Test vectorization of rotate byte and short
+ * @library /test/lib
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestRotateByteAndShortVector::testRotate* -Xbatch TestRotateByteAndShortVector
+ */
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class TestRotateByteAndShortVector {
+    private static final Random random = Utils.getRandomInstance();
+    private static final int ARRLEN = 512;
+    private static final int ITERS = 11000;
+
+    private static byte[] arrByte = new byte[ARRLEN];
+    private static byte[] rolByte = new byte[ARRLEN];
+    private static byte[] rorByte = new byte[ARRLEN];
+    private static byte   resByte = 0;
+
+    private static short[] arrShort = new short[ARRLEN];
+    private static short[] rolShort = new short[ARRLEN];
+    private static short[] rorShort = new short[ARRLEN];
+    private static short   resShort = 0;
+
+    public static void main(String[] args) {
+        System.out.println("warmup");
+        warmup();
+
+        System.out.println("Testing...");
+        runRotateLeftByteTest();
+        runRotateRightByteTest();
+        runRotateLeftShortTest();
+        runRotateRightShortTest();
+
+        System.out.println("PASSED");
+    }
+
+    static void warmup() {
+        random.nextBytes(arrByte);
+        randomShorts();
+        for (int i = 0; i < ITERS; i++) {
+            testRotateLeftByte(rolByte, arrByte, i);
+            testRotateRightByte(rorByte, arrByte, i);
+            testRotateLeftShort(rolShort, arrShort, i);
+            testRotateRightShort(rorShort, arrShort, i);
+        }
+    }
+
+    static void randomShorts() {
+        for (int i = 0; i < ARRLEN; i++) {
+            arrShort[i] = (short) random.nextInt();
+        }
+    }
+
+    static void runRotateLeftByteTest() {
+        for (int shift = 0; shift < 64; shift++) {
+            random.nextBytes(arrByte);
+            testRotateLeftByte(rolByte, arrByte, shift);
+            for (int i = 0; i < ARRLEN; i++) {
+                resByte = (byte) ((arrByte[i] << shift) | (arrByte[i] >>> -shift));
+                if (rolByte[i] != resByte) {
+                    throw new RuntimeException("rol value = " + arrByte[i] + ", shift = " + shift + ", error: " + "expect " + resByte + " but result is " + rolByte[i]);
+                }
+            }
+        }
+    }
+
+    static void runRotateRightByteTest() {
+        for (int shift = 0; shift < 64; shift++) {
+            random.nextBytes(arrByte);
+            testRotateRightByte(rorByte, arrByte, shift);
+            for (int i = 0; i < ARRLEN; i++) {
+                resByte = (byte) ((arrByte[i] >>> shift) | (arrByte[i] << -shift));
+                if (rorByte[i] != resByte) {
+                    throw new RuntimeException("ror value = " + arrByte[i] + ", shift = " + shift + ", error: " + "expect " + resByte + " but result is " + rorByte[i]);
+                }
+            }
+        }
+    }
+
+    static void runRotateLeftShortTest() {
+        for (int shift = 0; shift < 64; shift++) {
+            randomShorts();
+            testRotateLeftShort(rolShort, arrShort, shift);
+            for (int i = 0; i < ARRLEN; i++) {
+                resShort = (short) ((arrShort[i] << shift) | (arrShort[i] >>> -shift));
+                if (rolShort[i] != resShort) {
+                    throw new RuntimeException("rol value = " + arrShort[i] + ", shift = " + shift + ", error: " + "expect " + resShort + " but result is " + rolShort[i]);
+                }
+            }
+        }
+    }
+
+    static void runRotateRightShortTest() {
+        for (int shift = 0; shift < 64; shift++) {
+            randomShorts();
+            testRotateRightShort(rorShort, arrShort, shift);
+            for (int i = 0; i < ARRLEN; i++) {
+                resShort = (short) ((arrShort[i] >>> shift) | (arrShort[i] << -shift));
+                if (rorShort[i] != resShort) {
+                    throw new RuntimeException("ror value = " + arrShort[i] + ", shift = " + shift + ", error: " + "expect " + resShort + " but result is " + rorShort[i]);
+                }
+            }
+        }
+    }
+
+    static void testRotateLeftByte(byte[] test, byte[] arr, int shift) {
+        for (int i = 0; i < ARRLEN; i++) {
+            test[i] = (byte) ((arr[i] << shift) | (arr[i] >>> -shift));
+        }
+    }
+
+    static void testRotateRightByte(byte[] test, byte[] arr, int shift) {
+        for (int i = 0; i < ARRLEN; i++) {
+            test[i] = (byte) ((arr[i] >>> shift) | (arr[i] << -shift));
+        }
+    }
+
+    static void testRotateLeftShort(short[] test, short[] arr, int shift) {
+        for (int i = 0; i < ARRLEN; i++) {
+            test[i] = (short) ((arr[i] << shift) | (arr[i] >>> -shift));
+        }
+    }
+
+    static void testRotateRightShort(short[] test, short[] arr, int shift) {
+        for (int i = 0; i < ARRLEN; i++) {
+            test[i] = (short) ((arr[i] >>> shift) | (arr[i] << -shift));
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8286847](https://bugs.openjdk.java.net/browse/JDK-8286847). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286847](https://bugs.openjdk.org/browse/JDK-8286847): Rotate vectors don't support byte or short


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk18u pull/169/head:pull/169` \
`$ git checkout pull/169`

Update a local copy of the PR: \
`$ git checkout pull/169` \
`$ git pull https://git.openjdk.org/jdk18u pull/169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 169`

View PR using the GUI difftool: \
`$ git pr show -t 169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk18u/pull/169.diff">https://git.openjdk.org/jdk18u/pull/169.diff</a>

</details>
