### PR TITLE
8285885: Replay compilation fails with assert(is_valid()) failed: check invoke

### DIFF
--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -398,7 +398,12 @@ class CompileReplay : public StackObj {
 
       ik->link_class(CHECK_NULL);
 
-      Bytecode_invoke bytecode(caller, bci);
+      Bytecode_invoke bytecode = Bytecode_invoke_check(caller, bci);
+      if (!Bytecodes::is_defined(bytecode.code()) || !bytecode.is_valid()) {
+        report_error("no invoke found at bci");
+        return NULL;
+      }
+      bytecode.verify();
       int index = bytecode.index();
 
       ConstantPoolCacheEntry* cp_cache_entry = NULL;


### PR DESCRIPTION
Backport of [JDK-8285885](https://bugs.openjdk.java.net/browse/JDK-8285885). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285885](https://bugs.openjdk.org/browse/JDK-8285885): Replay compilation fails with assert(is_valid()) failed: check invoke


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk18u pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.org/jdk18u pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk18u/pull/170.diff">https://git.openjdk.org/jdk18u/pull/170.diff</a>

</details>
