### PR TITLE
8283890: Changes in CFG file format break C1Visualizer

### DIFF
--- a/src/hotspot/share/c1/c1_CFGPrinter.cpp
+++ b/src/hotspot/share/c1/c1_CFGPrinter.cpp
@@ -244,13 +244,11 @@ void CFGPrinterOutput::print_block(BlockBegin* block) {
   output()->cr();
 
   output()->indent();
+  output()->print("successors ");
   if (block->end() != NULL) {
-    output()->print("successors ");
     for (i = 0; i < block->number_of_sux(); i++) {
       output()->print("\"B%d\" ", block->sux_at(i)->block_id());
     }
-  } else {
-    output()->print("(block has no end, cannot print successors)");
   }
   output()->cr();
 


### PR DESCRIPTION
Backport of [JDK-8283890](https://bugs.openjdk.java.net/browse/JDK-8283890). Applies cleanly. Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283890](https://bugs.openjdk.org/browse/JDK-8283890): Changes in CFG file format break C1Visualizer


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk18u pull/171/head:pull/171` \
`$ git checkout pull/171`

Update a local copy of the PR: \
`$ git checkout pull/171` \
`$ git pull https://git.openjdk.org/jdk18u pull/171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 171`

View PR using the GUI difftool: \
`$ git pr show -t 171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk18u/pull/171.diff">https://git.openjdk.org/jdk18u/pull/171.diff</a>

</details>
