### PR TITLE
8283457: [macos] libpng build failures with Xcode13.3

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -742,7 +742,7 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
           maybe-uninitialized shift-negative-value implicit-fallthrough \
           unused-function, \
       DISABLED_WARNINGS_clang := incompatible-pointer-types sign-compare \
-          deprecated-declarations, \
+          deprecated-declarations null-pointer-subtraction, \
       DISABLED_WARNINGS_microsoft := 4018 4244 4267, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [33eb89df](https://github.com/openjdk/jdk/commit/33eb89dfeb4a43e1ad2c3dd657ec3b6ee7abbb3a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Phil Race on 22 Mar 2022 and was reviewed by Erik Joelsson.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283457](https://bugs.openjdk.org/browse/JDK-8283457): [macos] libpng build failures with Xcode13.3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk18u pull/174/head:pull/174` \
`$ git checkout pull/174`

Update a local copy of the PR: \
`$ git checkout pull/174` \
`$ git pull https://git.openjdk.org/jdk18u pull/174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 174`

View PR using the GUI difftool: \
`$ git pr show -t 174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk18u/pull/174.diff">https://git.openjdk.org/jdk18u/pull/174.diff</a>

</details>
